### PR TITLE
Retry PubSub streaming connections

### DIFF
--- a/src/retry_policy/exponential_backoff.rs
+++ b/src/retry_policy/exponential_backoff.rs
@@ -129,7 +129,7 @@ config_default! {
         @default(2.0, "Config::default_multiplier")
         pub multiplier: f32,
 
-        /// The number of times that retry attemps will be made before the underlying error is returned
+        /// The number of times that retry attempts will be made before the underlying error is returned
         ///
         /// A value of `None` will cause the retries to continue indefinitely
         @default(Some(16), "Config::default_max_retries")


### PR DESCRIPTION
Previously PubSub streaming would attempt to reconnect on failures while
reading messages, but not on the connection initiation. This change
includes the initiation in the retry logic.

This also changes the retry configuration for streaming connections to
match the values in the Java client library.