### PR TITLE
Update Tonic to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,12 +58,12 @@ derive_more = { version = "0.99", optional = true }
 hyper-openssl = { version = "0.9", optional = true }
 hyper-rustls = { version = "0.22", features = ["rustls-native-certs"], optional = true }
 pin-project = { version = "1", optional = true }
-prost = { version = "0.8", optional = true }
-prost-types = { version = "0.8", optional = true }
+prost = { version = "0.9", optional = true }
+prost-types = { version = "0.9", optional = true }
 tame-gcs = { version = "0.10.0", optional = true }
 tempdir = { version = "0.3", optional = true }
 tokio = { version = "1", features = ["time"], optional = true }
-tonic = { version = "0.5", optional = true }
+tonic = { version = "0.6.2", optional = true }
 tower = { version = "0.4", features = ["make"], optional = true }
 uuid = { version = "0.8.1", features = ["v4"], optional = true }
 

--- a/generators/Cargo.toml
+++ b/generators/Cargo.toml
@@ -16,12 +16,12 @@ harness = false
 [dependencies]
 anyhow = "1"
 flate2 = "1"
-prost-build = "0.8"
+prost-build = "0.9"
 reqwest = { version = "0.11", features = ["blocking"] }
 structopt = "0.3"
 tar = "0.4"
 tempfile = "3"
-tonic-build = "0.5"
+tonic-build = "0.6"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/src/auth/grpc.rs
+++ b/src/auth/grpc.rs
@@ -277,7 +277,7 @@ mod test {
         struct InjectedError;
 
         let mut auth_service = AuthGrpcService::new(
-            tonic::transport::Endpoint::from_static("localhost").connect_lazy()?,
+            tonic::transport::Endpoint::from_static("localhost").connect_lazy(),
             Some(|| async { Err::<String, _>(InjectedError) }),
         );
 
@@ -299,7 +299,7 @@ mod test {
         struct InjectedError;
 
         let mut auth_service = AuthGrpcService::new(
-            tonic::transport::Endpoint::from_static("localhost").connect_lazy()?,
+            tonic::transport::Endpoint::from_static("localhost").connect_lazy(),
             Some(|| async { Ok::<_, std::io::Error>("\u{0000}") }),
         );
 

--- a/src/generated/google.api.rs
+++ b/src/generated/google.api.rs
@@ -1,5 +1,5 @@
 /// Defines the HTTP configuration for an API service. It contains a list of
-/// [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
+/// \[HttpRule][google.api.HttpRule\], each specifying the mapping of an RPC method
 /// to one or more HTTP REST API methods.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Http {
@@ -22,10 +22,10 @@ pub struct Http {
 /// gRPC Transcoding is a feature for mapping between a gRPC method and one or
 /// more HTTP REST endpoints. It allows developers to build a single API service
 /// that supports both gRPC APIs and REST APIs. Many systems, including [Google
-/// APIs](https://github.com/googleapis/googleapis),
-/// [Cloud Endpoints](https://cloud.google.com/endpoints), [gRPC
-/// Gateway](https://github.com/grpc-ecosystem/grpc-gateway),
-/// and [Envoy](https://github.com/envoyproxy/envoy) proxy support this feature
+/// APIs](<https://github.com/googleapis/googleapis>),
+/// [Cloud Endpoints](<https://cloud.google.com/endpoints>), [gRPC
+/// Gateway](<https://github.com/grpc-ecosystem/grpc-gateway>),
+/// and \[Envoy\](<https://github.com/envoyproxy/envoy>) proxy support this feature
 /// and use it for large scale production services.
 ///
 /// `HttpRule` defines the schema of the gRPC/REST mapping. The mapping specifies
@@ -186,15 +186,15 @@ pub struct Http {
 /// 1. Leaf request fields (recursive expansion nested messages in the request
 ///    message) are classified into three categories:
 ///    - Fields referred by the path template. They are passed via the URL path.
-///    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They are passed via the HTTP
+///    - Fields referred by the \[HttpRule.body][google.api.HttpRule.body\]. They are passed via the HTTP
 ///      request body.
 ///    - All other fields are passed via the URL query parameters, and the
 ///      parameter name is the field path in the request message. A repeated
 ///      field can be represented as multiple query parameters under the same
 ///      name.
-///  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL query parameter, all fields
+///  2. If \[HttpRule.body][google.api.HttpRule.body\] is "*", there is no URL query parameter, all fields
 ///     are passed via URL path and HTTP request body.
-///  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP request body, all
+///  3. If \[HttpRule.body][google.api.HttpRule.body\] is omitted, there is no HTTP request body, all
 ///     fields are passed via URL path and URL query parameters.
 ///
 /// ### Path template syntax
@@ -221,19 +221,19 @@ pub struct Http {
 ///
 /// If a variable contains exactly one path segment, such as `"{var}"` or
 /// `"{var=*}"`, when such a variable is expanded into a URL path on the client
-/// side, all characters except `[-_.~0-9a-zA-Z]` are percent-encoded. The
+/// side, all characters except `\[-_.~0-9a-zA-Z\]` are percent-encoded. The
 /// server side does the reverse decoding. Such variables show up in the
 /// [Discovery
-/// Document](https://developers.google.com/discovery/v1/reference/apis) as
+/// Document](<https://developers.google.com/discovery/v1/reference/apis>) as
 /// `{var}`.
 ///
 /// If a variable contains multiple path segments, such as `"{var=foo/*}"`
 /// or `"{var=**}"`, when such a variable is expanded into a URL path on the
-/// client side, all characters except `[-_.~/0-9a-zA-Z]` are percent-encoded.
+/// client side, all characters except `\[-_.~/0-9a-zA-Z\]` are percent-encoded.
 /// The server side does the reverse decoding, except "%2F" and "%2f" are left
 /// unchanged. Such variables show up in the
 /// [Discovery
-/// Document](https://developers.google.com/discovery/v1/reference/apis) as
+/// Document](<https://developers.google.com/discovery/v1/reference/apis>) as
 /// `{+var}`.
 ///
 /// ## Using gRPC API Service Configuration
@@ -263,10 +263,10 @@ pub struct Http {
 ///
 /// When gRPC Transcoding is used to map a gRPC to JSON REST endpoints, the
 /// proto to JSON conversion must follow the [proto3
-/// specification](https://developers.google.com/protocol-buffers/docs/proto3#json).
+/// specification](<https://developers.google.com/protocol-buffers/docs/proto3#json>).
 ///
 /// While the single segment variable follows the semantics of
-/// [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2 Simple String
+/// [RFC 6570](<https://tools.ietf.org/html/rfc6570>) Section 3.2.2 Simple String
 /// Expansion, the multi segment variable **does not** follow RFC 6570 Section
 /// 3.2.3 Reserved Expansion. The reason is that the Reserved Expansion
 /// does not expand special characters like `?` and `#`, which would lead
@@ -290,7 +290,7 @@ pub struct Http {
 pub struct HttpRule {
     /// Selects a method to which this rule applies.
     ///
-    /// Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+    /// Refer to \[selector][google.api.DocumentationRule.selector\] for syntax details.
     #[prost(string, tag = "1")]
     pub selector: ::prost::alloc::string::String,
     /// The name of the request field whose value is mapped to the HTTP request
@@ -418,11 +418,7 @@ pub enum FieldBehavior {
 ///       // For Kubernetes resources, the format is {api group}/{kind}.
 ///       option (google.api.resource) = {
 ///         type: "pubsub.googleapis.com/Topic"
-///         name_descriptor: {
-///           pattern: "projects/{project}/topics/{topic}"
-///           parent_type: "cloudresourcemanager.googleapis.com/Project"
-///           parent_name_extractor: "projects/{project}"
-///         }
+///         pattern: "projects/{project}/topics/{topic}"
 ///       };
 ///     }
 ///
@@ -430,10 +426,7 @@ pub enum FieldBehavior {
 ///
 ///     resources:
 ///     - type: "pubsub.googleapis.com/Topic"
-///       name_descriptor:
-///         - pattern: "projects/{project}/topics/{topic}"
-///           parent_type: "cloudresourcemanager.googleapis.com/Project"
-///           parent_name_extractor: "projects/{project}"
+///       pattern: "projects/{project}/topics/{topic}"
 ///
 /// Sometimes, resources have multiple patterns, typically because they can
 /// live under multiple parents.
@@ -443,26 +436,10 @@ pub enum FieldBehavior {
 ///     message LogEntry {
 ///       option (google.api.resource) = {
 ///         type: "logging.googleapis.com/LogEntry"
-///         name_descriptor: {
-///           pattern: "projects/{project}/logs/{log}"
-///           parent_type: "cloudresourcemanager.googleapis.com/Project"
-///           parent_name_extractor: "projects/{project}"
-///         }
-///         name_descriptor: {
-///           pattern: "folders/{folder}/logs/{log}"
-///           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-///           parent_name_extractor: "folders/{folder}"
-///         }
-///         name_descriptor: {
-///           pattern: "organizations/{organization}/logs/{log}"
-///           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-///           parent_name_extractor: "organizations/{organization}"
-///         }
-///         name_descriptor: {
-///           pattern: "billingAccounts/{billing_account}/logs/{log}"
-///           parent_type: "billing.googleapis.com/BillingAccount"
-///           parent_name_extractor: "billingAccounts/{billing_account}"
-///         }
+///         pattern: "projects/{project}/logs/{log}"
+///         pattern: "folders/{folder}/logs/{log}"
+///         pattern: "organizations/{organization}/logs/{log}"
+///         pattern: "billingAccounts/{billing_account}/logs/{log}"
 ///       };
 ///     }
 ///
@@ -470,48 +447,10 @@ pub enum FieldBehavior {
 ///
 ///     resources:
 ///     - type: 'logging.googleapis.com/LogEntry'
-///       name_descriptor:
-///         - pattern: "projects/{project}/logs/{log}"
-///           parent_type: "cloudresourcemanager.googleapis.com/Project"
-///           parent_name_extractor: "projects/{project}"
-///         - pattern: "folders/{folder}/logs/{log}"
-///           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-///           parent_name_extractor: "folders/{folder}"
-///         - pattern: "organizations/{organization}/logs/{log}"
-///           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-///           parent_name_extractor: "organizations/{organization}"
-///         - pattern: "billingAccounts/{billing_account}/logs/{log}"
-///           parent_type: "billing.googleapis.com/BillingAccount"
-///           parent_name_extractor: "billingAccounts/{billing_account}"
-///
-/// For flexible resources, the resource name doesn't contain parent names, but
-/// the resource itself has parents for policy evaluation.
-///
-/// Example:
-///
-///     message Shelf {
-///       option (google.api.resource) = {
-///         type: "library.googleapis.com/Shelf"
-///         name_descriptor: {
-///           pattern: "shelves/{shelf}"
-///           parent_type: "cloudresourcemanager.googleapis.com/Project"
-///         }
-///         name_descriptor: {
-///           pattern: "shelves/{shelf}"
-///           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-///         }
-///       };
-///     }
-///
-/// The ResourceDescriptor Yaml config will look like:
-///
-///     resources:
-///     - type: 'library.googleapis.com/Shelf'
-///       name_descriptor:
-///         - pattern: "shelves/{shelf}"
-///           parent_type: "cloudresourcemanager.googleapis.com/Project"
-///         - pattern: "shelves/{shelf}"
-///           parent_type: "cloudresourcemanager.googleapis.com/Folder"
+///       pattern: "projects/{project}/logs/{log}"
+///       pattern: "folders/{folder}/logs/{log}"
+///       pattern: "organizations/{organization}/logs/{log}"
+///       pattern: "billingAccounts/{billing_account}/logs/{log}"
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceDescriptor {
     /// The resource type. It must be in the format of
@@ -521,7 +460,7 @@ pub struct ResourceDescriptor {
     /// Example: `storage.googleapis.com/Bucket`
     ///
     /// The value of the resource_type_kind must follow the regular expression
-    /// /[A-Za-z][a-zA-Z0-9]+/. It should start with an upper case character and
+    /// /\[A-Za-z][a-zA-Z0-9\]+/. It should start with an upper case character and
     /// should use PascalCase (UpperCamelCase). The maximum number of
     /// characters allowed for the `resource_type_kind` is 100.
     #[prost(string, tag = "1")]
@@ -572,14 +511,14 @@ pub struct ResourceDescriptor {
     /// 'projects' for the resource name of 'projects/{project}' and the permission
     /// name of 'cloudresourcemanager.googleapis.com/projects.get'. It is the same
     /// concept of the `plural` field in k8s CRD spec
-    /// https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+    /// <https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/>
     ///
     /// Note: The plural form is required even for singleton resources. See
-    /// https://aip.dev/156
+    /// <https://aip.dev/156>
     #[prost(string, tag = "5")]
     pub plural: ::prost::alloc::string::String,
     /// The same concept of the `singular` field in k8s CRD spec
-    /// https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+    /// <https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/>
     /// Such as "project" for the `resourcemanager.googleapis.com/Project` type.
     #[prost(string, tag = "6")]
     pub singular: ::prost::alloc::string::String,

--- a/src/generated/google.pubsub.v1.rs
+++ b/src/generated/google.pubsub.v1.rs
@@ -45,7 +45,7 @@ pub struct CreateSchemaRequest {
     /// The ID to use for the schema, which will become the final component of
     /// the schema's resource name.
     ///
-    /// See https://cloud.google.com/pubsub/docs/admin#resource_names for resource
+    /// See <https://cloud.google.com/pubsub/docs/admin#resource_names> for resource
     /// name constraints.
     #[prost(string, tag = "3")]
     pub schema_id: ::prost::alloc::string::String,
@@ -199,7 +199,7 @@ pub mod schema_service_client {
     impl<T> SchemaServiceClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + Send + Sync + 'static,
+        T::ResponseBody: Body + Send + 'static,
         T::Error: Into<StdError>,
         <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
@@ -368,14 +368,14 @@ pub struct SchemaSettings {
 pub struct Topic {
     /// Required. The name of the topic. It must have the format
     /// `"projects/{project}/topics/{topic}"`. `{topic}` must start with a letter,
-    /// and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`),
+    /// and contain only letters (`\[A-Za-z\]`), numbers (`\[0-9\]`), dashes (`-`),
     /// underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
     /// signs (`%`). It must be between 3 and 255 characters in length, and it
     /// must not start with `"goog"`.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// See [Creating and managing labels]
-    /// (https://cloud.google.com/pubsub/docs/labels).
+    /// (<https://cloud.google.com/pubsub/docs/labels>).
     #[prost(map = "string, string", tag = "2")]
     pub labels:
         ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
@@ -401,7 +401,7 @@ pub struct Topic {
     /// the topic. If this field is set, messages published to the topic in the
     /// last `message_retention_duration` are always available to subscribers. For
     /// instance, it allows any attached subscription to [seek to a
-    /// timestamp](https://cloud.google.com/pubsub/docs/replay-overview#seek_to_a_time)
+    /// timestamp](<https://cloud.google.com/pubsub/docs/replay-overview#seek_to_a_time>)
     /// that is up to `message_retention_duration` in the past. If this field is
     /// not set, message retention is controlled by settings on individual
     /// subscriptions. Cannot be more than 7 days or less than 10 minutes.
@@ -412,9 +412,9 @@ pub struct Topic {
 /// message must contain either a non-empty data field or at least one attribute.
 /// Note that client libraries represent this object differently
 /// depending on the language. See the corresponding [client library
-/// documentation](https://cloud.google.com/pubsub/docs/reference/libraries) for
+/// documentation](<https://cloud.google.com/pubsub/docs/reference/libraries>) for
 /// more information. See [quotas and limits]
-/// (https://cloud.google.com/pubsub/quotas) for more information about message
+/// (<https://cloud.google.com/pubsub/quotas>) for more information about message
 /// limits.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PubsubMessage {
@@ -600,8 +600,8 @@ pub struct DetachSubscriptionResponse {}
 pub struct Subscription {
     /// Required. The name of the subscription. It must have the format
     /// `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must
-    /// start with a letter, and contain only letters (`[A-Za-z]`), numbers
-    /// (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
+    /// start with a letter, and contain only letters (`\[A-Za-z\]`), numbers
+    /// (`\[0-9\]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
     /// plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters
     /// in length, and it must not start with `"goog"`.
     #[prost(string, tag = "1")]
@@ -642,7 +642,7 @@ pub struct Subscription {
     /// messages are not expunged from the subscription's backlog, even if they are
     /// acknowledged, until they fall out of the `message_retention_duration`
     /// window. This must be true if you would like to [`Seek` to a timestamp]
-    /// (https://cloud.google.com/pubsub/docs/replay-overview#seek_to_a_time) in
+    /// (<https://cloud.google.com/pubsub/docs/replay-overview#seek_to_a_time>) in
     /// the past to replay previously-acknowledged messages.
     #[prost(bool, tag = "7")]
     pub retain_acked_messages: bool,
@@ -654,7 +654,7 @@ pub struct Subscription {
     /// minutes.
     #[prost(message, optional, tag = "8")]
     pub message_retention_duration: ::core::option::Option<::prost_types::Duration>,
-    /// See <a href="https://cloud.google.com/pubsub/docs/labels"> Creating and
+    /// See <a href="<https://cloud.google.com/pubsub/docs/labels">> Creating and
     /// managing labels</a>.
     #[prost(map = "string, string", tag = "9")]
     pub labels:
@@ -674,7 +674,7 @@ pub struct Subscription {
     #[prost(message, optional, tag = "11")]
     pub expiration_policy: ::core::option::Option<ExpirationPolicy>,
     /// An expression written in the Pub/Sub [filter
-    /// language](https://cloud.google.com/pubsub/docs/filtering). If non-empty,
+    /// language](<https://cloud.google.com/pubsub/docs/filtering>). If non-empty,
     /// then only `PubsubMessage`s whose `attributes` field matches the filter are
     /// delivered on this subscription. If empty, then no messages are filtered
     /// out.
@@ -718,7 +718,7 @@ pub struct Subscription {
 /// A policy that specifies how Cloud Pub/Sub retries message delivery.
 ///
 /// Retry delay will be exponential based on provided minimum and maximum
-/// backoffs. https://en.wikipedia.org/wiki/Exponential_backoff.
+/// backoffs. <https://en.wikipedia.org/wiki/Exponential_backoff.>
 ///
 /// RetryPolicy will be triggered on NACKs or acknowledgement deadline exceeded
 /// events for a given message.
@@ -788,7 +788,7 @@ pub struct ExpirationPolicy {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PushConfig {
     /// A URL locating the endpoint to which messages should be pushed.
-    /// For example, a Webhook endpoint might use `https://example.com/push`.
+    /// For example, a Webhook endpoint might use `<https://example.com/push`.>
     #[prost(string, tag = "1")]
     pub push_endpoint: ::prost::alloc::string::String,
     /// Endpoint configuration attributes that can be used to control different
@@ -827,11 +827,11 @@ pub struct PushConfig {
 pub mod push_config {
     /// Contains information needed for generating an
     /// [OpenID Connect
-    /// token](https://developers.google.com/identity/protocols/OpenIDConnect).
+    /// token](<https://developers.google.com/identity/protocols/OpenIDConnect>).
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct OidcToken {
         /// [Service account
-        /// email](https://cloud.google.com/iam/docs/service-accounts)
+        /// email](<https://cloud.google.com/iam/docs/service-accounts>)
         /// to be used for generating the OIDC token. The caller (for
         /// CreateSubscription, UpdateSubscription, and ModifyPushConfig RPCs) must
         /// have the iam.serviceAccounts.actAs permission for the service account.
@@ -841,7 +841,7 @@ pub mod push_config {
         /// identifies the recipients that the JWT is intended for. The audience
         /// value is a single case-sensitive string. Having multiple values (array)
         /// for the audience field is not supported. More info about the OIDC JWT
-        /// token audience here: https://tools.ietf.org/html/rfc7519#section-4.1.3
+        /// token audience here: <https://tools.ietf.org/html/rfc7519#section-4.1.3>
         /// Note: if not specified, the Push endpoint URL will be used.
         #[prost(string, tag = "2")]
         pub audience: ::prost::alloc::string::String,
@@ -1129,7 +1129,7 @@ pub struct CreateSnapshotRequest {
     /// in the request, the server will assign a random name for this snapshot on
     /// the same project as the subscription. Note that for REST API requests, you
     /// must specify a name.  See the <a
-    /// href="https://cloud.google.com/pubsub/docs/admin#resource_names"> resource
+    /// href="<https://cloud.google.com/pubsub/docs/admin#resource_names">> resource
     /// name rules</a>. Format is `projects/{project}/snapshots/{snap}`.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
@@ -1144,7 +1144,7 @@ pub struct CreateSnapshotRequest {
     /// Format is `projects/{project}/subscriptions/{sub}`.
     #[prost(string, tag = "2")]
     pub subscription: ::prost::alloc::string::String,
-    /// See <a href="https://cloud.google.com/pubsub/docs/labels"> Creating and
+    /// See <a href="<https://cloud.google.com/pubsub/docs/labels">> Creating and
     /// managing labels</a>.
     #[prost(map = "string, string", tag = "3")]
     pub labels:
@@ -1162,7 +1162,7 @@ pub struct UpdateSnapshotRequest {
     pub update_mask: ::core::option::Option<::prost_types::FieldMask>,
 }
 /// A snapshot resource. Snapshots are used in
-/// [Seek](https://cloud.google.com/pubsub/docs/replay-overview)
+/// \[Seek\](<https://cloud.google.com/pubsub/docs/replay-overview>)
 /// operations, which allow you to manage message acknowledgments in bulk. That
 /// is, you can set the acknowledgment state of messages in an existing
 /// subscription to the state captured by a snapshot.
@@ -1187,7 +1187,7 @@ pub struct Snapshot {
     #[prost(message, optional, tag = "3")]
     pub expire_time: ::core::option::Option<::prost_types::Timestamp>,
     /// See [Creating and managing labels]
-    /// (https://cloud.google.com/pubsub/docs/labels).
+    /// (<https://cloud.google.com/pubsub/docs/labels>).
     #[prost(map = "string, string", tag = "4")]
     pub labels:
         ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
@@ -1295,7 +1295,7 @@ pub mod publisher_client {
     impl<T> PublisherClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + Send + Sync + 'static,
+        T::ResponseBody: Body + Send + 'static,
         T::Error: Into<StdError>,
         <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
@@ -1519,7 +1519,7 @@ pub mod subscriber_client {
     impl<T> SubscriberClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + Send + Sync + 'static,
+        T::ResponseBody: Body + Send + 'static,
         T::Error: Into<StdError>,
         <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {

--- a/src/pubsub/publish_sink.rs
+++ b/src/pubsub/publish_sink.rs
@@ -694,9 +694,7 @@ mod test {
         // is made (then it will error). That's good enough for testing certain functionality
         // that doesn't require the requests themselves, like validity checking
         ApiPublisherClient::new(crate::auth::grpc::oauth_grpc(
-            tonic::transport::channel::Endpoint::from_static("https://localhost")
-                .connect_lazy()
-                .unwrap(),
+            tonic::transport::channel::Endpoint::from_static("https://localhost").connect_lazy(),
             None,
             vec![],
         ))


### PR DESCRIPTION
This brings in a new version of the gRPC library Tonic. This may help
fix some bugs[1] in status codes.

This also necessitates an upgrade to Prost 0.9. Protobuf-generated
sources have been updated, though it appears the only differences is
some doc formatting

[1]: https://github.com/hyperium/tonic/pull/629