### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
       - name: Install PubSub Emulator
         run: gcloud components install beta pubsub-emulator
       - uses: actions/checkout@v2
@@ -45,8 +45,8 @@ jobs:
       matrix:
         rust_toolchain: [""] # "" = rust-toolchain version
         os: [windows-latest, macOS-latest]
-        test_flags: ["", "--no-default-features", "--features pubsub,storage,tokio"]
-    timeout-minutes: 8
+        test_flags: ["--features pubsub,storage,tokio"]
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ tower = { version = "0.4", features = ["make"], optional = true }
 uuid = { version = "0.8.1", features = ["v4"], optional = true }
 
 [dev-dependencies]
+approx = "0.5"
 async-stream = "0.3"
 quickcheck = "1"
 quickcheck_macros = "1"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -212,11 +212,9 @@ where
                 )
             })?;
 
-    Ok(
-        yup_oauth2::ServiceAccountAuthenticator::builder(service_account_key)
-            .hyper_client(client)
-            .build()
-            .await
-            .map_err(CreateBuilderError::Authenticator)?,
-    )
+    yup_oauth2::ServiceAccountAuthenticator::builder(service_account_key)
+        .hyper_client(client)
+        .build()
+        .await
+        .map_err(CreateBuilderError::Authenticator)
 }


### PR DESCRIPTION
Builds were failing because gcloud github actions changed a branch name
which we depended on explicitly; now our CI uses a (hopefully stable)
tag instead.

Additionally, some tests were stochastically failing, likely due to
rounding errors in some float code. Those have been adjusted to use
approximate equality.

There was also a lint failing. Code was updated to comply.

Finally, some of the test runs were reduced on cross-platform CI as they
were largely redundant and not super useful.