### PR TITLE
Add Application Default Credentials via Instance Metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,7 +1925,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "ya-gcp"
-version = "0.7.3"
+version = "0.7.5"
 dependencies = [
  "approx",
  "async-channel",

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -192,7 +192,7 @@ impl<C> ClientBuilder<C> {
                             std::env::var_os(SERVICE_ACCOUNT_ENV_VAR)
                                 .ok_or(CreateBuilderError::CredentialsVarMissing)?,
                         ),
-                        _ => None,
+                        ServiceAccountAuth::ApplicationDefault => None,
                     },
                     client.clone(),
                 )
@@ -237,7 +237,7 @@ where
                 .await
                 .map_err(CreateBuilderError::Authenticator)
         }
-        _ => match yup_oauth2::ApplicationDefaultCredentialsAuthenticator::with_client(
+        None => match yup_oauth2::ApplicationDefaultCredentialsAuthenticator::with_client(
             yup_oauth2::ApplicationDefaultCredentialsFlowOpts::default(),
             client,
         )


### PR DESCRIPTION
Allow passing `ServiceAccountAuth::ApplicationDefault` when creating a new authenticator. This should force it to detect the default service account which is attached to compute instances.

Please make any suggestions to the API, as I'm not certain if this is the proper way to implement this. I also took the liberty of using features from the upgraded version of `yup_oauth2`, which seemed to fit the requirements, over `gcp-auth` which was suggested in comments.