### PR TITLE
First cut at bigtable support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
     steps:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
-      - name: Install PubSub Emulator
-        run: gcloud components install beta pubsub-emulator
+      - name: Install Emulators
+        run: gcloud components install beta pubsub-emulator bigtable
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "ya-gcp"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "approx",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ async-channel = { version = "1", optional = true }
 derive_more = { version = "0.99", optional = true }
 hyper-openssl = { version = "0.9", optional = true }
 hyper-rustls = { version = "0.22", features = ["rustls-native-certs"], optional = true }
-pin-project = { version = "1", optional = true }
+pin-project = { version = "1.0.11", optional = true }
 prost = { version = "0.9", optional = true }
 prost-types = { version = "0.9", optional = true }
 tame-gcs = { version = "0.10.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ name = "storage_get_object"
 path = "examples/storage_get_object.rs"
 required-features = ["storage"]
 
+[[example]]
+name = "bigtable"
+path = "examples/bigtable.rs"
+required-features = ["bigtable"]
+
 [features]
 default = ["rustls", "tokio"]
 
@@ -33,6 +38,7 @@ openssl = ["hyper-openssl"] # TODO maybe should be native-tls instead?
 # an internal feature used by services running grpc
 grpc = ["tonic", "prost", "prost-types", "tower", "derive_more"]
 
+bigtable = ["async-stream", "grpc", "prost", "tower"]
 pubsub = ["grpc", "uuid", "async-stream", "pin-project", "async-channel", "tokio", "tokio/time"]
 storage = ["tame-gcs"]
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Platform (GCP)](https://cloud.google.com/) services.
 
 **Alpha maturity**:
 - Google Cloud Storage
+- Bigtable
 
 Different service APIs can be accessed through modules enabled with
 compile-time features. See the list of supported features below. Service
@@ -26,6 +27,7 @@ The following flags can be enabled to change what code is included
 Services:
 - `pubsub` enables the PubSub API
 - `storage` enables the GCS API
+- `bigtable` enables the Bigtable API
 
 Miscellaneous:
 - `rustls` use Rustls for TLS support, enabled by default

--- a/examples/bigtable.rs
+++ b/examples/bigtable.rs
@@ -1,0 +1,97 @@
+use futures::stream::StreamExt;
+use structopt::StructOpt;
+
+use ya_gcp::{
+    bigtable::{self, admin::Rule},
+    AuthFlow, ClientBuilder, ClientBuilderConfig, ServiceAccountAuth,
+};
+
+#[derive(Debug, StructOpt)]
+struct Args {
+    /// A path to the oauth service account key json file
+    #[structopt(long)]
+    service_account_key: Option<std::path::PathBuf>,
+
+    #[structopt(long)]
+    project_name: String,
+
+    #[structopt(long)]
+    instance_name: String,
+
+    #[structopt(long)]
+    table_name: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::from_args();
+
+    let auth = if let Some(key) = args.service_account_key {
+        AuthFlow::ServiceAccount(ServiceAccountAuth::Path(key))
+    } else {
+        AuthFlow::NoAuth
+    };
+
+    let config = ClientBuilderConfig::new().auth_flow(auth);
+    let builder = ClientBuilder::new(config).await?;
+
+    let mut bigtable_admin_config = bigtable::admin::BigtableTableAdminConfig::default();
+    let mut bigtable_config = bigtable::BigtableConfig::default();
+
+    if let Ok(host) = std::env::var("BIGTABLE_EMULATOR_HOST") {
+        bigtable_admin_config.endpoint = host.clone();
+        bigtable_config.endpoint = host;
+    };
+
+    let mut admin = builder
+        .build_bigtable_admin_client(
+            bigtable_admin_config,
+            &args.project_name,
+            &args.instance_name,
+        )
+        .await?;
+
+    match admin
+        .create_table(
+            &args.table_name,
+            [("family-name".to_owned(), Rule::MaxNumVersions(10))],
+        )
+        .await
+    {
+        Ok(table) => println!("created table {:?}", table),
+        Err(e) => {
+            if e.code() == tonic::Code::AlreadyExists {
+                println!("table already exists");
+            } else {
+                println!("unexpected error");
+                Err(e)?;
+            }
+        }
+    }
+
+    let tables: Vec<_> = admin.list_tables().await?.collect().await;
+    println!("got tables {:?}", tables);
+
+    let mut client = builder
+        .build_bigtable_client(bigtable_config, &args.project_name, &args.instance_name)
+        .await?;
+
+    client
+        .set_row_data(
+            &args.table_name,
+            "family-name".to_string(),
+            "row00",
+            [("col1", "value"), ("col2", "value")],
+        )
+        .await?;
+    println!("set data done");
+    println!(
+        "all data: {:?}",
+        client
+            .read_row_range(&args.table_name, .., Some(100))
+            .collect::<Vec<_>>()
+            .await
+    );
+
+    Ok(())
+}

--- a/generators/src/grpc.rs
+++ b/generators/src/grpc.rs
@@ -43,6 +43,17 @@ fn main() -> Result<(), Error> {
     // the wire
     prost_config.bytes(&["."]);
 
+    // The bigtable docs have doc comments that trigger test failures.
+    // (TODO: in newer versions of prost-build, the `format` option might be enough for this)
+    prost_config.disable_comments(&[
+        "bigtable.v2.RowFilter.Interleave.filters",
+        "bigtable.v2.RowFilter.sink",
+        "iam.v1.Policy",
+        "iam.v1.AuditConfig",
+        "iam.v1.AuditLogConfig",
+        "type.Expr",
+    ]);
+
     // the attributes map tend to have a small number of string keys, which are faster to access
     // using a btree than a hashmap. See the crate's benchmarks
     prost_config.btree_map(&["PubsubMessage.attributes"]);
@@ -54,11 +65,15 @@ fn main() -> Result<(), Error> {
         .out_dir(&args.output_dir)
         .compile_with_config(
             prost_config,
-            ["google/pubsub/v1/pubsub.proto"]
-                .iter()
-                .map(|src| google_protos.join(src))
-                .collect::<Vec<_>>()
-                .as_ref(),
+            [
+                "google/pubsub/v1/pubsub.proto",
+                "google/bigtable/v2/bigtable.proto",
+                "google/bigtable/admin/v2/bigtable_table_admin.proto",
+            ]
+            .iter()
+            .map(|src| google_protos.join(src))
+            .collect::<Vec<_>>()
+            .as_ref(),
             &[google_protos],
         )
         .context("failed to generate rust sources")?;

--- a/src/bigtable/admin.rs
+++ b/src/bigtable/admin.rs
@@ -1,0 +1,170 @@
+//! An API for administering bigtable.
+
+use crate::{
+    auth::grpc::{self, AuthGrpcService, OAuthTokenSource},
+    builder,
+};
+
+use super::api::bigtable::admin;
+
+pub use admin::v2::Table;
+use futures::Stream;
+
+// TODO: https://cloud.google.com/bigtable/docs/reference/admin/rpc/google.bigtable.admin.v2#google.bigtable.admin.v2.BigtableTableAdmin
+// lists lots of different scopes. What's the difference between them?
+const BIGTABLE_ADMIN_SCOPE: &'static str = "https://www.googleapis.com/auth/bigtable.admin";
+
+config_default! {
+    /// Configuration for the bigtable admin client
+    #[derive(Debug, Clone, Eq, PartialEq, Hash, serde::Deserialize)]
+    #[non_exhaustive]
+    pub struct BigtableTableAdminConfig {
+        /// Endpoint to connect to bigtable over.
+        @default("https://bigtableadmin.googleapis.com".into(), "BigtableTableAdminConfig::default_endpoint")
+        pub endpoint: String,
+    }
+}
+
+/// A client for connecting to bigtable. Created from the
+/// [`build_bigtable_client`](crate::builder::ClientBuilder::build_bigtable_client)
+/// function.
+#[derive(Clone)]
+pub struct BigtableTableAdminClient<C = crate::DefaultConnector> {
+    pub(crate) inner: admin::v2::bigtable_table_admin_client::BigtableTableAdminClient<
+        AuthGrpcService<tonic::transport::Channel, OAuthTokenSource<C>>,
+    >,
+    // A string of the form projects/{project}/instances/{instance}
+    pub(crate) table_prefix: String,
+}
+
+pub use admin::v2::gc_rule::Rule;
+use http::Uri;
+use tower::make::MakeConnection;
+
+impl Rule {
+    /// Take the union of this rule with `other`.
+    pub fn union(self, other: Rule) -> Rule {
+        match self {
+            Rule::Union(mut union) => {
+                union.rules.push(other.into());
+                Rule::Union(union)
+            }
+            r => Rule::Union(admin::v2::gc_rule::Union {
+                rules: vec![r.into(), other.into()],
+            }),
+        }
+    }
+
+    /// Take the intersection of this rule with `other`.
+    pub fn intersection(self, other: Rule) -> Rule {
+        match self {
+            Rule::Intersection(mut int) => {
+                int.rules.push(other.into());
+                Rule::Intersection(int)
+            }
+            r => Rule::Intersection(admin::v2::gc_rule::Intersection {
+                rules: vec![r.into(), other.into()],
+            }),
+        }
+    }
+}
+
+impl From<Rule> for admin::v2::GcRule {
+    fn from(rule: Rule) -> admin::v2::GcRule {
+        admin::v2::GcRule { rule: Some(rule) }
+    }
+}
+
+impl<C> BigtableTableAdminClient<C>
+where
+    C: crate::Connect + Clone + Send + Sync + 'static,
+{
+    /// Create a new table.
+    pub async fn create_table<Fams>(
+        &mut self,
+        table_name: &str,
+        column_families: Fams,
+    ) -> Result<Table, tonic::Status>
+    where
+        Fams: IntoIterator<Item = (String, Rule)>,
+    {
+        let table_id = table_name.to_owned();
+        let table = Table {
+            name: format!("{}/tables/{}", self.table_prefix, table_name),
+            column_families: column_families
+                .into_iter()
+                .map(|(name, rule)| {
+                    (
+                        name,
+                        admin::v2::ColumnFamily {
+                            gc_rule: Some(rule.into()),
+                        },
+                    )
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let req = admin::v2::CreateTableRequest {
+            parent: self.table_prefix.clone(),
+            table_id,
+            table: Some(table),
+            ..Default::default()
+        };
+
+        let response = self.inner.create_table(req).await?;
+        Ok(response.into_inner())
+    }
+
+    /// List all tables.
+    pub async fn list_tables(
+        &mut self,
+    ) -> Result<impl Stream<Item = Result<Table, tonic::Status>>, tonic::Status> {
+        let req = admin::v2::ListTablesRequest {
+            parent: self.table_prefix.clone(),
+            ..Default::default()
+        };
+        let response = self.inner.list_tables(req).await?;
+        // TODO: if the response was paged, make a follow-up request.
+        Ok(futures::stream::iter(
+            response.into_inner().tables.into_iter().map(|x| Ok(x)),
+        ))
+    }
+}
+
+/// An error encountered when building Bigtable table admin clients
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct BuildError(#[from] tonic::transport::Error);
+
+impl<C> builder::ClientBuilder<C>
+where
+    C: MakeConnection<Uri> + crate::Connect + Clone + Send + Sync + 'static,
+    C::Connection: Unpin + Send + 'static,
+    C::Future: Send + 'static,
+    Box<dyn std::error::Error + Send + Sync + 'static>: From<C::Error>,
+{
+    /// Create a client for administering bigtable tables.
+    pub async fn build_bigtable_admin_client(
+        &self,
+        config: BigtableTableAdminConfig,
+        project: &str,
+        instance_name: &str,
+    ) -> Result<BigtableTableAdminClient<C>, BuildError> {
+        let scopes = vec![BIGTABLE_ADMIN_SCOPE.to_owned()];
+        let endpoint = tonic::transport::Endpoint::new(config.endpoint)?;
+
+        let connection = endpoint
+            .connect_with_connector(self.connector.clone())
+            .await?;
+        let table_prefix = format!("projects/{}/instances/{}", project, instance_name);
+
+        let inner = admin::v2::bigtable_table_admin_client::BigtableTableAdminClient::new(
+            grpc::oauth_grpc(connection, self.auth.clone(), scopes),
+        );
+
+        Ok(BigtableTableAdminClient {
+            inner,
+            table_prefix,
+        })
+    }
+}

--- a/src/bigtable/client_builder.rs
+++ b/src/bigtable/client_builder.rs
@@ -1,0 +1,87 @@
+use crate::{
+    auth::grpc,
+    bigtable::{api, BigtableClient},
+    builder,
+    retry_policy::{exponential_backoff, ExponentialBackoff},
+};
+
+const BIGTABLE_DATA_SCOPE: &'static str = "https://www.googleapis.com/auth/bigtable.data";
+const BIGTABLE_DATA_READONLY_SCOPE: &'static str =
+    "https://www.googleapis.com/auth/bigtable.data.readonly";
+
+config_default! {
+    /// Configuration for connecting to bigtable
+    #[derive(Debug, Clone, Eq, PartialEq, Hash, serde::Deserialize)]
+    #[non_exhaustive]
+    pub struct BigtableConfig {
+        /// Endpoint to connect to bigtable over.
+        @default("https://bigtable.googleapis.com".into(), "BigtableConfig::default_endpoint")
+        pub endpoint: String,
+
+        /// Whether this client should be created with only read permission.
+        @default(false, "BigtableConfig::default_readonly")
+        pub readonly: bool,
+    }
+}
+
+impl BigtableConfig {
+    fn auth_scopes(&self) -> Vec<String> {
+        if self.readonly {
+            vec![BIGTABLE_DATA_READONLY_SCOPE.to_owned()]
+        } else {
+            vec![BIGTABLE_DATA_SCOPE.to_owned()]
+        }
+    }
+}
+
+/// An error encountered when building Bigtable clients
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct BuildError(#[from] tonic::transport::Error);
+
+// re-export traits and types necessary for the bounds on public functions
+#[allow(unreachable_pub)] // the reachability lint seems faulty with parent module re-exports
+pub use http::Uri;
+#[allow(unreachable_pub)]
+pub use tower::make::MakeConnection;
+
+use super::BigtableRetryCheck;
+
+impl<C> builder::ClientBuilder<C>
+where
+    C: MakeConnection<Uri> + crate::Connect + Clone + Send + Sync + 'static,
+    C::Connection: Unpin + Send + 'static,
+    C::Future: Send + 'static,
+    Box<dyn std::error::Error + Send + Sync + 'static>: From<C::Error>,
+{
+    /// Create a client for connecting to bigtable
+    pub async fn build_bigtable_client(
+        &self,
+        config: BigtableConfig,
+        project: &str,
+        instance_name: &str,
+    ) -> Result<BigtableClient<C>, BuildError> {
+        let scopes = config.auth_scopes();
+        let endpoint = tonic::transport::Endpoint::new(config.endpoint)?;
+
+        let connection = endpoint
+            .connect_with_connector(self.connector.clone())
+            .await?;
+        let table_prefix = format!("projects/{}/instances/{}/tables/", project, instance_name);
+
+        let inner = api::bigtable::v2::bigtable_client::BigtableClient::new(grpc::oauth_grpc(
+            connection,
+            self.auth.clone(),
+            scopes,
+        ));
+
+        Ok(BigtableClient {
+            inner,
+            table_prefix,
+            retry: ExponentialBackoff::new(
+                BigtableRetryCheck::default(),
+                exponential_backoff::Config::default(),
+            ),
+        })
+    }
+}

--- a/src/bigtable/emulator.rs
+++ b/src/bigtable/emulator.rs
@@ -1,0 +1,110 @@
+//! Testing infra to make use of the bigtable emulator.
+//! <https://cloud.google.com/bigtable/docs/emulator>
+//!
+//! Follow installation directions from link above to set up your local development. Once setup,
+//! you should be able to run the pubsub emulator driven tests.
+
+use futures::{future::BoxFuture, FutureExt};
+
+use crate::{
+    bigtable,
+    builder::ClientBuilder,
+    emulator::{self, EmulatorData},
+};
+
+type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Struct to hold a started PubSub emulator process. Process is closed when struct is dropped.
+pub struct EmulatorClient {
+    inner: crate::emulator::EmulatorClient,
+    instance: String,
+}
+
+const DATA: EmulatorData = EmulatorData {
+    gcloud_param: "bigtable",
+    kill_pattern: "bigtable",
+    availability_check: create_bigtable_client,
+    extra_args: Vec::new(),
+};
+
+const INSTANCE_ID: &str = "test-instance";
+
+impl EmulatorClient {
+    /// Create a new emulator instance with a default project name and instance name
+    pub async fn new() -> Result<Self, BoxError> {
+        Ok(EmulatorClient {
+            inner: emulator::EmulatorClient::new(DATA).await?,
+            instance: INSTANCE_ID.into(),
+        })
+    }
+
+    /// Create a new emulator instance with the given project name and instance name
+    pub async fn with_project_and_instance(
+        project_name: impl Into<String>,
+        instance_name: impl Into<String>,
+    ) -> Result<Self, BoxError> {
+        Ok(EmulatorClient {
+            inner: emulator::EmulatorClient::with_project(DATA, project_name).await?,
+            instance: instance_name.into(),
+        })
+    }
+
+    /// Get the endpoint at which the emulator is listening for requests
+    pub fn endpoint(&self) -> String {
+        self.inner.endpoint()
+    }
+
+    /// Get the project name with which the emulator was initialized
+    pub fn project(&self) -> &str {
+        self.inner.project()
+    }
+
+    /// Get the instance name with which the emulator was initialized
+    pub fn instance(&self) -> &str {
+        &self.instance
+    }
+
+    /// Get a client builder which is pre-configured to work with this emulator instance
+    pub fn builder(&self) -> &ClientBuilder {
+        self.inner.builder()
+    }
+
+    /// Create a new table under this emulator's given project name and instance name.
+    ///
+    /// The column families will be created wth effectively no garbage collection.
+    pub async fn create_table(
+        &self,
+        table_name: &str,
+        column_families: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Result<(), BoxError> {
+        let config = bigtable::admin::BigtableTableAdminConfig {
+            endpoint: self.endpoint(),
+            ..bigtable::admin::BigtableTableAdminConfig::default()
+        };
+
+        let mut admin = self
+            .builder()
+            .build_bigtable_admin_client(config, &self.project(), &self.instance)
+            .await?;
+
+        let column_families = column_families
+            .into_iter()
+            .map(|name| (name.into(), bigtable::admin::Rule::MaxNumVersions(i32::MAX)));
+        admin.create_table(table_name, column_families).await?;
+
+        Ok(())
+    }
+}
+
+fn create_bigtable_client(port: &str) -> BoxFuture<Result<(), tonic::transport::Error>> {
+    async move {
+        bigtable::api::bigtable::v2::bigtable_client::BigtableClient::connect(format!(
+            "http://{}:{}",
+            crate::emulator::HOST,
+            port
+        ))
+        .await?;
+        Ok(())
+    }
+    .boxed()
+}

--- a/src/bigtable/filters.rs
+++ b/src/bigtable/filters.rs
@@ -1,0 +1,29 @@
+//! Builders for contructing filters, used when reading bigtable rows.
+
+use super::api::bigtable::v2;
+
+pub use v2::row_filter::{Chain, Filter};
+
+impl Chain {
+    /// Add a new filter to the end of this chain, returning the result.
+    pub fn with_filter(mut self, filter: Filter) -> Self {
+        self.filters.push(v2::RowFilter {
+            filter: Some(filter),
+        });
+        self
+    }
+}
+
+impl From<Chain> for Filter {
+    fn from(ch: Chain) -> Filter {
+        Filter::Chain(ch)
+    }
+}
+
+impl<T: Into<Filter>> From<T> for v2::RowFilter {
+    fn from(f: T) -> v2::RowFilter {
+        v2::RowFilter {
+            filter: Some(f.into()),
+        }
+    }
+}

--- a/src/bigtable/mod.rs
+++ b/src/bigtable/mod.rs
@@ -168,11 +168,11 @@ pub struct CellRef<'a> {
     /// The column family name
     pub family_name: &'a str,
     /// The column qualifier
-    pub column_qualifier: &'a prost::bytes::Bytes,
+    pub column_qualifier: &'a [u8],
     /// The cell's timestamp, in microseconds since the epoch
     pub timestamp_micros: i64,
     /// The cell's contents
-    pub value: &'a prost::bytes::Bytes,
+    pub value: &'a [u8],
 }
 
 impl Row {

--- a/src/bigtable/mod.rs
+++ b/src/bigtable/mod.rs
@@ -23,6 +23,10 @@ pub mod mutation;
 pub use client_builder::BigtableConfig;
 pub use mutation::{MutateRowRequest, MutateRowsError, MutateRowsRequest};
 
+#[cfg(feature = "emulators")]
+#[cfg_attr(docsrs, doc(cfg(feature = "emulators")))]
+pub mod emulator;
+
 #[allow(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, missing_docs)]
 pub mod api {
     pub mod rpc {

--- a/src/bigtable/mod.rs
+++ b/src/bigtable/mod.rs
@@ -1,0 +1,590 @@
+//! TODO(docs!)
+
+// Primitives for reading/writing Bigtable tables
+
+use futures::prelude::*;
+use hyper::body::Bytes;
+use prost::bytes::BytesMut;
+use std::ops::{Bound, RangeBounds};
+
+use crate::{
+    auth::grpc::{AuthGrpcService, OAuthTokenSource},
+    retry_policy::{ExponentialBackoff, RetryOperation, RetryPolicy, RetryPredicate},
+};
+
+pub use http::Uri;
+pub use tower::make::MakeConnection;
+
+pub mod admin;
+mod client_builder;
+pub mod filters;
+pub mod mutation;
+
+pub use client_builder::BigtableConfig;
+pub use mutation::{MutateRowRequest, MutateRowsError, MutateRowsRequest};
+
+#[allow(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, missing_docs)]
+pub mod api {
+    pub mod rpc {
+        include!("../generated/google.rpc.rs");
+    }
+    pub mod longrunning {
+        include!("../generated/google.longrunning.rs");
+    }
+    pub mod iam {
+        pub mod v1 {
+            include!("../generated/google.iam.v1.rs");
+        }
+    }
+    pub mod r#type {
+        include!("../generated/google.type.rs");
+    }
+    pub mod bigtable {
+        pub mod v2 {
+            include!("../generated/google.bigtable.v2.rs");
+        }
+
+        pub mod admin {
+            pub mod v2 {
+                include!("../generated/google.bigtable.admin.v2.rs");
+            }
+        }
+    }
+}
+
+use api::bigtable::v2;
+
+pub use api::bigtable::v2::ReadRowsRequest;
+
+pub use api::bigtable::v2::{RowRange, RowSet};
+
+fn bound_to_start_key(bound: Bound<&Bytes>) -> Option<v2::row_range::StartKey> {
+    use v2::row_range::StartKey;
+    match bound {
+        Bound::Included(b) => Some(StartKey::StartKeyClosed(b.clone())),
+        Bound::Excluded(b) => Some(StartKey::StartKeyOpen(b.clone())),
+        Bound::Unbounded => None,
+    }
+}
+
+fn bound_to_end_key(bound: Bound<&Bytes>) -> Option<v2::row_range::EndKey> {
+    use v2::row_range::EndKey;
+    match bound {
+        Bound::Included(b) => Some(EndKey::EndKeyClosed(b.clone())),
+        Bound::Excluded(b) => Some(EndKey::EndKeyOpen(b.clone())),
+        Bound::Unbounded => None,
+    }
+}
+
+impl RowRange {
+    // Take just the part of this range that's strictly after `key`, returning true if the resulting
+    // range is non-empty. (This API is a little weird; the point is that you're supposed to use
+    // it in `Vec::retain_mut`.)
+    fn restrict_to_after(&mut self, key: &Bytes) -> bool {
+        use v2::row_range::{EndKey, StartKey};
+        match &self.end_key {
+            Some(EndKey::EndKeyOpen(b)) | Some(EndKey::EndKeyClosed(b)) if b <= key => {
+                return false
+            }
+            _ => {}
+        }
+
+        let replace_start_key = match &self.start_key {
+            Some(StartKey::StartKeyOpen(b)) if b >= key => false,
+            Some(StartKey::StartKeyClosed(b)) if b > key => false,
+            _ => true,
+        };
+
+        if replace_start_key {
+            self.start_key = Some(StartKey::StartKeyOpen(key.clone()));
+        }
+        true
+    }
+}
+
+impl RowSet {
+    /// Add a range of rows to this row set.
+    // TODO: it would be nice to take types more general than Bytes, but the
+    // RangeBounds trait makes that annoying: it doesn't allow extracting the
+    // start/end by value.
+    pub fn with_range(mut self, range: impl RangeBounds<Bytes>) -> Self {
+        let start_key = bound_to_start_key(range.start_bound());
+        let end_key = bound_to_end_key(range.end_bound());
+        let range = v2::RowRange { start_key, end_key };
+        self.row_ranges.push(range);
+        self
+    }
+
+    /// Add a single row to this row set.
+    pub fn with_key(mut self, key: impl Into<Bytes>) -> Self {
+        self.row_keys.push(key.into());
+        self
+    }
+
+    fn restrict_to_after(&mut self, key: Bytes) {
+        self.row_ranges.retain_mut(|r| r.restrict_to_after(&key));
+        self.row_keys.retain(|r| r > &key);
+    }
+}
+
+/// The default [`RetryPredicate`] used for errors from Bigtable operations
+#[derive(Debug, Default, Clone)]
+pub struct BigtableRetryCheck {
+    _priv: (),
+}
+
+impl BigtableRetryCheck {
+    /// Create a new instance with default settings
+    pub fn new() -> Self {
+        Self { _priv: () }
+    }
+}
+
+impl RetryPredicate<tonic::Status> for BigtableRetryCheck {
+    fn is_retriable(&self, error: &tonic::Status) -> bool {
+        use tonic::Code;
+
+        // this error code check is based on the ones used in the Go bigtable client lib:
+        // https://github.com/googleapis/google-cloud-go/blob/66e8e2717b2593f4e5640ecb97344bb1d5e5fc0b/bigtable/bigtable.go#L107
+
+        match error.code() {
+            Code::DeadlineExceeded | Code::Unavailable | Code::Aborted => true,
+            _ => false,
+        }
+    }
+}
+
+pub use api::bigtable::v2::{Cell, Column, Family, Row};
+
+/// A reference for a single cell in Bigtable
+pub struct CellRef<'a> {
+    /// The column family name
+    pub family_name: &'a str,
+    /// The column qualifier
+    pub column_qualifier: &'a prost::bytes::Bytes,
+    /// The cell's timestamp, in microseconds since the epoch
+    pub timestamp_micros: i64,
+    /// The cell's contents
+    pub value: &'a prost::bytes::Bytes,
+}
+
+impl Row {
+    /// Iterate over this row's cells, returning only the most recent cell in each column
+    pub fn most_recent_cells(&self) -> impl Iterator<Item = CellRef<'_>> + '_ {
+        self.families.iter().flat_map(|fam| {
+            fam.columns.iter().filter_map(move |col| {
+                // The cells vec is *decreasing* in `timestamp_micros`
+                col.cells.first().map(move |cell| CellRef {
+                    family_name: &fam.name,
+                    column_qualifier: &col.qualifier,
+                    timestamp_micros: cell.timestamp_micros,
+                    value: &cell.value,
+                })
+            })
+        })
+    }
+}
+
+#[derive(Default)]
+struct ReadInProgress {
+    row: Row,
+    value: BytesMut,
+}
+
+impl ReadInProgress {
+    fn flush_bytes_in_progress(&mut self) {
+        if !self.value.is_empty() {
+            let value = self.value.split().freeze();
+            if let Some(cell) = self.last_cell_mut() {
+                cell.value = value;
+            }
+        }
+    }
+
+    fn new_family(&mut self, name: String) {
+        self.flush_bytes_in_progress();
+        if self.row.families.last().map(|fam| &fam.name) != Some(&name) {
+            self.row.families.push(Family {
+                name,
+                ..Default::default()
+            });
+        }
+    }
+
+    fn new_column(&mut self, qualifier: Bytes) {
+        self.flush_bytes_in_progress();
+        if let Some(family) = self.row.families.last_mut() {
+            if family.columns.last().map(|col| &col.qualifier) != Some(&qualifier) {
+                family.columns.push(Column {
+                    qualifier,
+                    ..Default::default()
+                });
+            }
+        }
+    }
+
+    fn last_column_mut(&mut self) -> Option<&mut Column> {
+        self.row
+            .families
+            .last_mut()
+            .and_then(|family| family.columns.last_mut())
+    }
+
+    fn new_cell(&mut self, timestamp_micros: i64, value_size: i32) {
+        self.flush_bytes_in_progress();
+        if let Some(col) = self.last_column_mut() {
+            col.cells.push(Cell {
+                timestamp_micros,
+                ..Default::default()
+            });
+            self.value = BytesMut::with_capacity(value_size as usize);
+        }
+    }
+
+    fn last_cell_mut(&mut self) -> Option<&mut Cell> {
+        self.last_column_mut().and_then(|col| col.cells.last_mut())
+    }
+
+    fn finish_row(&mut self) -> Row {
+        self.flush_bytes_in_progress();
+        std::mem::replace(&mut self.row, Default::default())
+    }
+
+    // Process a chunk, and return a row if one was completed.
+    //
+    // Bigtable responds in chunks, where a row can be split across chunks (but every chunk
+    // contains at most one row).
+    fn process_chunk(&mut self, chunk: v2::read_rows_response::CellChunk) -> Option<Row> {
+        if !chunk.row_key.is_empty() {
+            // We don't need to check if there's an existing row to store, because
+            // RowStatus tells us when to do that.
+            self.row.key = chunk.row_key;
+        }
+
+        if let Some(family_name) = chunk.family_name {
+            self.new_family(family_name);
+        }
+
+        if let Some(qualifier) = chunk.qualifier {
+            self.new_column(qualifier.into());
+        }
+
+        if Some(chunk.timestamp_micros) != self.last_cell_mut().map(|cell| cell.timestamp_micros) {
+            self.new_cell(chunk.timestamp_micros, chunk.value_size);
+        }
+
+        // TODO: in the (presumably reasonably common case that the buffer comes
+        // in a single chunk, we should avoid copying the data.
+        self.value.extend_from_slice(&chunk.value);
+
+        if let Some(row_status) = chunk.row_status {
+            let row = self.finish_row();
+            if matches!(
+                row_status,
+                v2::read_rows_response::cell_chunk::RowStatus::CommitRow(_),
+            ) {
+                return Some(row);
+            }
+        }
+        None
+    }
+}
+
+/// A client for connecting to bigtable. Created from the
+/// [`build_bigtable_client`](crate::builder::ClientBuilder::build_bigtable_client)
+/// function.
+#[derive(Clone)]
+pub struct BigtableClient<
+    C = crate::DefaultConnector,
+    Retry = ExponentialBackoff<BigtableRetryCheck>,
+> {
+    inner: api::bigtable::v2::bigtable_client::BigtableClient<
+        AuthGrpcService<tonic::transport::Channel, OAuthTokenSource<C>>,
+    >,
+    retry: Retry,
+    table_prefix: String,
+}
+
+impl<C, Retry> BigtableClient<C, Retry>
+where
+    C: crate::Connect + Clone + Send + Sync + 'static,
+    Retry: RetryPolicy<(), tonic::Status> + 'static,
+    Retry::RetryOp: Send + 'static,
+    <Retry::RetryOp as RetryOperation<(), tonic::Status>>::Sleep: Send + 'static,
+{
+    /// Request some rows from bigtable.
+    ///
+    /// This is the most general read request; various other convenience methods are
+    /// available.
+    pub fn read_rows(
+        &mut self,
+        mut request: ReadRowsRequest,
+    ) -> impl Stream<Item = Result<Row, tonic::Status>> + '_ {
+        async_stream::stream! {
+            let mut retry = self.retry.new_operation();
+            let mut state = ReadInProgress::default();
+
+            // Keep track of the last returned (and/or last scanned) key, so that we won't
+            // request it again if we need to retry.
+            let mut last_key: Option<Bytes> = None;
+
+            let mut response = self.inner.read_rows(request.clone()).await?.into_inner();
+            let result = loop {
+                let message = match response.next().await {
+                    Some(m) => m,
+                    None => break Ok(()),
+                };
+
+                let message = match message {
+                    Ok(m) => m,
+                    Err(e) => break Err(e),
+                };
+
+                last_key = Some(
+                    last_key
+                        .unwrap_or_default()
+                        .max(message.last_scanned_row_key),
+                );
+
+                for chunk in message.chunks {
+                    if let Some(row) = state.process_chunk(chunk) {
+                        last_key = Some(last_key.unwrap_or_default().max(row.key.clone()));
+                        yield Ok(row);
+                    }
+                }
+            };
+
+            if let Err(e) = result {
+                if let Some(sleep) = retry.check_retry(&(), &e) {
+                    sleep.await;
+                } else {
+                    yield Err(e.into());
+                    return;
+                }
+            } else {
+                return;
+            }
+
+            // If we get to this point, there was a retry-able error. We'll loop back and retry the
+            // request again, but first let's modify the request to avoid re-requesting previously-returned
+            // data.
+            if let Some(key) = last_key {
+                if let Some(rows) = request.rows.as_mut() {
+                    rows.restrict_to_after(key);
+                }
+            }
+        }
+    }
+
+    /// Queries a range of rows from a table, returning just the keys.
+    pub fn read_row_range_keys(
+        &mut self,
+        table_name: &str,
+        range: impl RangeBounds<Bytes>,
+        rows_limit: Option<i64>,
+    ) -> impl Stream<Item = Result<Bytes, tonic::Status>> + '_ {
+        use filters::{Chain, Filter};
+        let table_name = format!("{}{}", self.table_prefix, table_name);
+        let req = ReadRowsRequest {
+            table_name,
+            rows_limit: rows_limit.unwrap_or(0),
+            rows: Some(v2::RowSet::default().with_range(range)),
+            filter: Some(
+                Chain::default()
+                    // Return the minimal number of cells per row
+                    .with_filter(Filter::CellsPerRowLimitFilter(1))
+                    // Return the minimal number of cells per column
+                    .with_filter(Filter::CellsPerColumnLimitFilter(1))
+                    // Strip off the cell data
+                    .with_filter(Filter::StripValueTransformer(true))
+                    .into(),
+            ),
+            ..Default::default()
+        };
+        self.read_rows(req)
+            .map(|maybe_row| maybe_row.map(|row| row.key))
+    }
+
+    /// Queries a range of rows from a table, returning only the most recent value of each cell.
+    pub fn read_row_range(
+        &mut self,
+        table_name: &str,
+        range: impl RangeBounds<Bytes>,
+        rows_limit: Option<i64>,
+    ) -> impl Stream<Item = Result<Row, tonic::Status>> + '_ {
+        let table_name = format!("{}{}", self.table_prefix, table_name);
+        let req = ReadRowsRequest {
+            table_name,
+            rows_limit: rows_limit.unwrap_or(0),
+            rows: Some(v2::RowSet::default().with_range(range)),
+            filter: Some(filters::Filter::CellsPerColumnLimitFilter(1).into()),
+            ..Default::default()
+        };
+        self.read_rows(req)
+    }
+
+    /// Queries a single row from a table, returning on the most recent value of each cell.
+    pub async fn read_one_row(
+        &mut self,
+        table_name: &str,
+        row_key: impl Into<Bytes>,
+    ) -> Result<Option<Row>, tonic::Status> {
+        let table_name = format!("{}{}", self.table_prefix, table_name);
+        let req = ReadRowsRequest {
+            table_name,
+            rows: Some(v2::RowSet::default().with_key(row_key)),
+            filter: Some(filters::Filter::CellsPerColumnLimitFilter(1).into()),
+            ..Default::default()
+        };
+        let stream = self.read_rows(req);
+        Box::pin(stream).next().await.transpose()
+    }
+
+    /// Performs a batch mutation request.
+    ///
+    /// This is the most general mutation request; various convenience methods are also available.
+    pub async fn mutate_rows(&mut self, request: MutateRowsRequest) -> Result<(), MutateRowsError> {
+        let mut retry = self.retry.new_operation();
+
+        let mut response = loop {
+            match self.inner.mutate_rows(request.clone()).await {
+                Ok(resp) => {
+                    break resp.into_inner();
+                }
+                Err(e) => {
+                    if let Some(sleep) = retry.check_retry(&(), &e) {
+                        sleep.await;
+                    } else {
+                        return Err(e.into());
+                    }
+                }
+            }
+        };
+
+        // Collect all entries in all responses with a bad status code.
+        let mut errors = Vec::new();
+        while let Some(res) = response.message().await? {
+            errors.extend(res.entries.into_iter().filter(|entry| {
+                entry.status.as_ref().map(|status| status.code != 0) == Some(true)
+            }));
+        }
+
+        if !errors.is_empty() {
+            Err(errors.into())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Performs a mutation request for a single row.
+    pub async fn mutate_row(&mut self, request: MutateRowRequest) -> Result<(), tonic::Status> {
+        let mut retry = self.retry.new_operation();
+
+        while let Err(e) = self.inner.mutate_row(request.clone()).await {
+            if let Some(sleep) = retry.check_retry(&(), &e) {
+                sleep.await;
+            } else {
+                return Err(e);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Delete one or more rows from the table.
+    pub async fn delete_rows(
+        &mut self,
+        table_name: &str,
+        row_keys: impl IntoIterator<Item = impl Into<Bytes>>,
+    ) -> Result<(), MutateRowsError> {
+        let table_name = format!("{}{}", self.table_prefix, table_name);
+        let req =
+            MutateRowsRequest::new(table_name).with_entries(row_keys.into_iter().map(|row_key| {
+                mutation::Entry::new(row_key.into()).with_mutation(mutation::DeleteFromRow {})
+            }));
+        self.mutate_rows(req).await
+    }
+
+    /// Set some data for a single row.
+    pub async fn set_row_data<RowKey, RowData, ColName, CellData>(
+        &mut self,
+        table_name: &str,
+        family_name: String,
+        row_key: RowKey,
+        data: RowData,
+    ) -> Result<(), tonic::Status>
+    where
+        RowKey: Into<Bytes>,
+        ColName: Into<Bytes>,
+        CellData: Into<Bytes>,
+        RowData: IntoIterator<Item = (ColName, CellData)>,
+    {
+        self.set_row_data_with_timestamp(table_name, family_name, -1, row_key, data)
+            .await
+    }
+
+    /// Set data for a collection of rows, all having the same table name and column family name.
+    ///
+    /// If `timestamp` is `None`, the bigtable server will be in charge of choosing the timestamp.
+    /// For more on the purpose of the `timestamp` field, see
+    /// [Google's docs](https://cloud.google.com/bigtable/docs/garbage-collection#timestamps).
+    pub async fn set_rows_data<RowKey, RowData, ColName, CellData>(
+        &mut self,
+        table_name: &str,
+        family_name: String,
+        timestamp: Option<i64>,
+        data: impl IntoIterator<Item = (RowKey, RowData)>,
+    ) -> Result<(), MutateRowsError>
+    where
+        RowKey: Into<Bytes>,
+        ColName: Into<Bytes>,
+        CellData: Into<Bytes>,
+        RowData: IntoIterator<Item = (ColName, CellData)>,
+    {
+        let table_name = format!("{}{}", self.table_prefix, table_name);
+        let req = MutateRowsRequest::new(table_name).with_entries(data.into_iter().map(
+            |(row_key, row_data)| {
+                mutation::Entry::new(row_key.into()).with_mutations(row_data.into_iter().map(
+                    |(col_name, cell_data)| {
+                        mutation::SetCell::new(
+                            family_name.clone(),
+                            col_name.into(),
+                            cell_data.into(),
+                        )
+                        .with_timestamp(timestamp.unwrap_or(-1))
+                    },
+                ))
+            },
+        ));
+
+        self.mutate_rows(req).await
+    }
+
+    /// Set some data for a single row.
+    ///
+    /// For more on the purpose of the `timestamp` field, see
+    /// [Google's docs](https://cloud.google.com/bigtable/docs/garbage-collection#timestamps).
+    pub async fn set_row_data_with_timestamp<RowKey, RowData, ColName, CellData>(
+        &mut self,
+        table_name: &str,
+        family_name: String,
+        timestamp: i64,
+        row_key: RowKey,
+        data: RowData,
+    ) -> Result<(), tonic::Status>
+    where
+        RowKey: Into<Bytes>,
+        ColName: Into<Bytes>,
+        CellData: Into<Bytes>,
+        RowData: IntoIterator<Item = (ColName, CellData)>,
+    {
+        let table_name = format!("{}{}", self.table_prefix, table_name);
+        let req = MutateRowRequest::new(table_name, row_key.into()).with_mutations(
+            data.into_iter().map(|(col_name, cell_data)| {
+                mutation::SetCell::new(family_name.clone(), col_name.into(), cell_data.into())
+                    .with_timestamp(timestamp)
+            }),
+        );
+        self.mutate_row(req).await
+    }
+}

--- a/src/bigtable/mutation.rs
+++ b/src/bigtable/mutation.rs
@@ -1,0 +1,157 @@
+//! Types and builders for requesting bigtable mutations.
+
+pub use super::api::bigtable::v2::{
+    self, mutate_rows_request::Entry, mutation::*, MutateRowRequest, MutateRowsRequest,
+};
+
+use super::Bytes;
+
+impl SetCell {
+    /// Create a new `SetCell` mutation for setting the value of a single cell.
+    pub fn new(family_name: String, column_qualifier: Bytes, value: Bytes) -> SetCell {
+        SetCell {
+            family_name,
+            column_qualifier,
+            value,
+            ..Default::default()
+        }
+    }
+
+    /// Set the timestamp value of this `SetCell` mutation.
+    ///
+    /// The special value `-1` means that the
+    /// [server provides the timestamp](https://cloud.google.com/bigtable/docs/reference/data/rpc/google.bigtable.v2#google.bigtable.v2.Mutation.SetCell).
+    pub fn with_timestamp(mut self, timestamp_micros: i64) -> Self {
+        self.timestamp_micros = timestamp_micros;
+        self
+    }
+}
+
+impl Entry {
+    /// Create a new `Entry` for modifying the given row.
+    pub fn new(row_key: Bytes) -> Self {
+        Entry {
+            row_key,
+            ..Default::default()
+        }
+    }
+
+    /// Add a mutation to this Entry.
+    pub fn with_mutation(mut self, mutation: impl Into<Mutation>) -> Self {
+        self.mutations.push(super::v2::Mutation {
+            mutation: Some(mutation.into()),
+        });
+        self
+    }
+
+    /// Add a list of mutations to this Entry.
+    pub fn with_mutations(
+        mut self,
+        mutations: impl IntoIterator<Item = impl Into<Mutation>>,
+    ) -> Self {
+        self.mutations
+            .extend(mutations.into_iter().map(|mutation| super::v2::Mutation {
+                mutation: Some(mutation.into()),
+            }));
+        self
+    }
+}
+
+impl From<SetCell> for Mutation {
+    fn from(sc: SetCell) -> Mutation {
+        Mutation::SetCell(sc)
+    }
+}
+
+impl From<DeleteFromColumn> for Mutation {
+    fn from(dfc: DeleteFromColumn) -> Mutation {
+        Mutation::DeleteFromColumn(dfc)
+    }
+}
+
+impl From<DeleteFromFamily> for Mutation {
+    fn from(dff: DeleteFromFamily) -> Mutation {
+        Mutation::DeleteFromFamily(dff)
+    }
+}
+
+impl From<DeleteFromRow> for Mutation {
+    fn from(dfr: DeleteFromRow) -> Mutation {
+        Mutation::DeleteFromRow(dfr)
+    }
+}
+
+/// The error returned from a row mutation request.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum MutateRowsError {
+    /// A gRPC error.
+    #[error("gRPC error: {0}")]
+    Tonic(#[from] tonic::Status),
+
+    /// An error mutating one or more specific rows.
+    #[error("row mutation error")]
+    RowErrors(Vec<v2::mutate_rows_response::Entry>),
+}
+
+impl From<Vec<v2::mutate_rows_response::Entry>> for MutateRowsError {
+    fn from(entries: Vec<v2::mutate_rows_response::Entry>) -> Self {
+        MutateRowsError::RowErrors(entries)
+    }
+}
+
+impl MutateRowRequest {
+    /// Create a new request for modifying a specific row.
+    pub fn new(table_name: String, row_key: Bytes) -> MutateRowRequest {
+        MutateRowRequest {
+            table_name,
+            row_key,
+            ..Default::default()
+        }
+    }
+
+    /// Add a mutation to this request.
+    pub fn with_mutation(mut self, mutation: impl Into<Mutation>) -> Self {
+        self.mutations.push(v2::Mutation {
+            mutation: Some(mutation.into()),
+        });
+        self
+    }
+
+    /// Add a list of mutations to this request.
+    pub fn with_mutations(
+        mut self,
+        mutations: impl IntoIterator<Item = impl Into<Mutation>>,
+    ) -> Self {
+        self.mutations
+            .extend(mutations.into_iter().map(|mutation| v2::Mutation {
+                mutation: Some(mutation.into()),
+            }));
+        self
+    }
+}
+
+impl MutateRowsRequest {
+    /// Create a new request for modifying multiple rows.
+    ///
+    /// See [Google's docs](https://cloud.google.com/bigtable/docs/writing-data#batch) for advice
+    /// about when to batch writes.
+    pub fn new(table_name: String) -> MutateRowsRequest {
+        MutateRowsRequest {
+            table_name,
+            ..Default::default()
+        }
+    }
+
+    /// Add an entry to this request.
+    pub fn with_entry(mut self, entry: Entry) -> Self {
+        self.entries.push(entry);
+        self
+    }
+
+    /// Add a list of entries to this request.
+    pub fn with_entries(mut self, entries: impl Iterator<Item = Entry>) -> Self {
+        self.entries.extend(entries);
+        self
+    }
+}

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1,0 +1,189 @@
+//! Testing infra to make use of the pubsub emulator.
+//! <https://cloud.google.com/pubsub/docs/emulator>
+//!
+//! Follow installation directions from link above to set up your local development. Once setup,
+//! you should be able to run the pubsub emulator driven tests.
+//!
+//! For a new test, create a new instance of [`EmulatorClient`]. Under the hood, this will find an
+//! open port and start a new pubsub emulator server. The port is used to create subscription and
+//! publish clients on the `EmulatorClient` instance.
+//!
+//! Cleanup:
+//! When the test ends (in success or failure) the Drop trait implementation of [`EmulatorClient`]
+//! ensures the system cleans up after itself. To verify the system cleaned up after itself run
+//! `ps aux | grep pubsub`. If there are open pubsub servers, run `pkill -f pubsub` to remove them
+//! all.
+
+use std::{ffi::OsString, ops::Range};
+
+use crate::builder::{AuthFlow, ClientBuilder, ClientBuilderConfig};
+use futures::future::BoxFuture;
+use rand::{self, Rng};
+use tracing::debug;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+const PROJECT_ID: &str = "test-project";
+const PORT_RANGE: Range<usize> = 8000..12000;
+pub(crate) const HOST: &str = "localhost";
+const CLI_RETRY: usize = 100;
+const CLIENT_CONNECT_RETRY: usize = 50;
+
+#[derive(Clone)]
+pub(crate) struct EmulatorData {
+    // The command `gcloud beta emulators <what goes here?> start` starts the emulator.
+    pub(crate) gcloud_param: &'static str,
+    // Extra parameters to be passed to `gcloud beta emulators <something> start`.
+    pub(crate) extra_args: Vec<OsString>,
+    // To shut down extra emulator processes, search for this string.
+    pub(crate) kill_pattern: &'static str,
+    // A function returning `Ok` if the emulator has finished starting up.
+    pub(crate) availability_check: fn(&str) -> BoxFuture<Result<(), tonic::transport::Error>>,
+}
+
+/// Struct to hold a started PubSub emulator process. Process is closed when struct is dropped.
+pub(crate) struct EmulatorClient {
+    // Child process running the pubsub emulator. Killed on drop, `wait`ed by tokio in the
+    // background afterward.
+    _child: tokio::process::Child,
+
+    // The port where the emulator is running. e.g. 8050
+    port: String,
+
+    builder: ClientBuilder,
+
+    project_name: String,
+
+    data: EmulatorData,
+}
+
+impl EmulatorClient {
+    /// Create a new emulator instance with a default project name
+    pub(crate) async fn new(data: EmulatorData) -> Result<Self, BoxError> {
+        Self::with_project(data, PROJECT_ID).await
+    }
+
+    /// Create a new emulator instance with the given project name
+    pub(crate) async fn with_project(
+        data: EmulatorData,
+        project_name: impl Into<String>,
+    ) -> Result<Self, BoxError> {
+        let project_name = project_name.into();
+
+        let (child, port) =
+            start_emulator(data.gcloud_param, &project_name, &data.extra_args).await?;
+        debug!("Started emulator");
+
+        // Give the server some time (5s) to come up.
+        let mut err: Option<tonic::transport::Error> = None;
+        let check = data.availability_check;
+        for _ in 0..CLIENT_CONNECT_RETRY {
+            // If we are able to create a schema client, then the server is up.
+            match check(&port).await {
+                Err(e) => {
+                    err = Some(e);
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+                Ok(_) => {
+                    err = None;
+                    break;
+                }
+            }
+        }
+
+        if let Some(err) = err {
+            return Err(err.into());
+        }
+
+        let config = ClientBuilderConfig {
+            auth_flow: AuthFlow::NoAuth,
+        };
+        let builder = ClientBuilder::new(config).await?;
+
+        Ok(Self {
+            _child: child,
+            port,
+            builder,
+            project_name,
+            data,
+        })
+    }
+
+    /// Get the endpoint at which the emulator is listening for requests
+    pub(crate) fn endpoint(&self) -> String {
+        format!("http://{}:{}/v1", HOST, self.port)
+    }
+
+    /// Get the project name with which the emulator was initialized
+    pub(crate) fn project(&self) -> &str {
+        &self.project_name
+    }
+
+    /// Get a client builder which is pre-configured to work with this emulator instance
+    pub(crate) fn builder(&self) -> &ClientBuilder {
+        &self.builder
+    }
+}
+
+/// Hacked callback to ensure the emulator process cleans up after itself.
+impl Drop for EmulatorClient {
+    fn drop(&mut self) {
+        // Search by name for other pubsub processes with --port=PORT in the cmd name and kill
+        // them. https://googlecloudplatform.uservoice.com/forums/302631-cloud-pub-sub/suggestions/42574147-java-process-spawned-when-pub-sub-emulator-runs-is
+        tokio::spawn(
+            tokio::process::Command::new("pkill")
+                .arg("-f")
+                .arg(format!(
+                    ".*{}.*--port={}.*",
+                    self.data.kill_pattern, self.port
+                ))
+                .output(),
+        );
+    }
+}
+
+/// Attempt to start the PubSub emulator. Sometimes theres a port collision and this might fail
+/// so attempt it multiple times.
+async fn start_emulator(
+    emulator_name: &str,
+    project_name: &str,
+    extra_args: &[OsString],
+) -> Result<(tokio::process::Child, String), std::io::Error> {
+    let mut err: Option<_> = None;
+    let mut rng = rand::thread_rng();
+
+    for _ in 0..CLI_RETRY {
+        let port = format!("{}", rng.gen_range(PORT_RANGE));
+        match start_emulator_once(emulator_name, &port, project_name, extra_args) {
+            Ok(child) => return Ok((child, port)),
+            Err(e) => {
+                err = Some(e);
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+    }
+    Err(err.unwrap())
+}
+
+/// Attempt to start the PubSub emulator. Sometimes theres a port collision and this might fail.
+fn start_emulator_once(
+    emulator_name: &str,
+    port: &str,
+    project_name: &str,
+    extra_args: &[OsString],
+) -> Result<tokio::process::Child, std::io::Error> {
+    tokio::process::Command::new("gcloud")
+        .arg("beta")
+        .arg("emulators")
+        .arg(emulator_name)
+        .arg("start")
+        .arg("--project")
+        .arg(project_name)
+        .arg("--host-port")
+        .arg(format!("{}:{}", HOST, port))
+        .args(extra_args)
+        .arg("--verbosity")
+        .arg("debug")
+        .kill_on_drop(true)
+        .spawn()
+}

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -12,8 +12,8 @@
 //! Cleanup:
 //! When the test ends (in success or failure) the Drop trait implementation of [`EmulatorClient`]
 //! ensures the system cleans up after itself. To verify the system cleaned up after itself run
-//! `ps aux | grep pubsub`. If there are open pubsub servers, run `pkill -f pubsub` to remove them
-//! all.
+//! `ps aux | grep pubsub`. If there are open pubsub/bigtable servers, run `pkill -f $service`
+//! (where `$service` is one of either `pubsub` or `bigtable`) to remove them all.
 
 use std::{ffi::OsString, ops::Range};
 

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1,7 +1,8 @@
-//! Testing infra to make use of the pubsub emulator.
+//! Testing infra to make use of GCP emulators.
 //! <https://cloud.google.com/pubsub/docs/emulator>
+//! <https://cloud.google.com/bigtable/docs/emulator>
 //!
-//! Follow installation directions from link above to set up your local development. Once setup,
+//! Follow installation directions from links above to set up your local development. Once setup,
 //! you should be able to run the pubsub emulator driven tests.
 //!
 //! For a new test, create a new instance of [`EmulatorClient`]. Under the hood, this will find an

--- a/src/generated/google.api.rs
+++ b/src/generated/google.api.rs
@@ -361,6 +361,310 @@ pub struct CustomHttpPattern {
     #[prost(string, tag = "2")]
     pub path: ::prost::alloc::string::String,
 }
+/// The launch stage as defined by [Google Cloud Platform
+/// Launch Stages](<https://cloud.google.com/terms/launch-stages>).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum LaunchStage {
+    /// Do not use this default value.
+    Unspecified = 0,
+    /// The feature is not yet implemented. Users can not use it.
+    Unimplemented = 6,
+    /// Prelaunch features are hidden from users and are only visible internally.
+    Prelaunch = 7,
+    /// Early Access features are limited to a closed group of testers. To use
+    /// these features, you must sign up in advance and sign a Trusted Tester
+    /// agreement (which includes confidentiality provisions). These features may
+    /// be unstable, changed in backward-incompatible ways, and are not
+    /// guaranteed to be released.
+    EarlyAccess = 1,
+    /// Alpha is a limited availability test for releases before they are cleared
+    /// for widespread use. By Alpha, all significant design issues are resolved
+    /// and we are in the process of verifying functionality. Alpha customers
+    /// need to apply for access, agree to applicable terms, and have their
+    /// projects allowlisted. Alpha releases don't have to be feature complete,
+    /// no SLAs are provided, and there are no technical support obligations, but
+    /// they will be far enough along that customers can actually use them in
+    /// test environments or for limited-use tests -- just like they would in
+    /// normal production cases.
+    Alpha = 2,
+    /// Beta is the point at which we are ready to open a release for any
+    /// customer to use. There are no SLA or technical support obligations in a
+    /// Beta release. Products will be complete from a feature perspective, but
+    /// may have some open outstanding issues. Beta releases are suitable for
+    /// limited production use cases.
+    Beta = 3,
+    /// GA features are open to all developers and are considered stable and
+    /// fully qualified for production use.
+    Ga = 4,
+    /// Deprecated features are scheduled to be shut down and removed. For more
+    /// information, see the "Deprecation Policy" section of our [Terms of
+    /// Service](<https://cloud.google.com/terms/>)
+    /// and the [Google Cloud Platform Subject to the Deprecation
+    /// Policy](<https://cloud.google.com/terms/deprecation>) documentation.
+    Deprecated = 5,
+}
+/// Required information for every language.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommonLanguageSettings {
+    /// Link to automatically generated reference documentation.  Example:
+    /// <https://cloud.google.com/nodejs/docs/reference/asset/latest>
+    #[prost(string, tag = "1")]
+    pub reference_docs_uri: ::prost::alloc::string::String,
+    /// The destination where API teams want this client library to be published.
+    #[prost(enumeration = "ClientLibraryDestination", repeated, tag = "2")]
+    pub destinations: ::prost::alloc::vec::Vec<i32>,
+}
+/// Details about how and where to publish client libraries.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ClientLibrarySettings {
+    /// Version of the API to apply these settings to.
+    #[prost(string, tag = "1")]
+    pub version: ::prost::alloc::string::String,
+    /// Launch stage of this version of the API.
+    #[prost(enumeration = "LaunchStage", tag = "2")]
+    pub launch_stage: i32,
+    /// When using transport=rest, the client request will encode enums as
+    /// numbers rather than strings.
+    #[prost(bool, tag = "3")]
+    pub rest_numeric_enums: bool,
+    /// Settings for legacy Java features, supported in the Service YAML.
+    #[prost(message, optional, tag = "21")]
+    pub java_settings: ::core::option::Option<JavaSettings>,
+    /// Settings for C++ client libraries.
+    #[prost(message, optional, tag = "22")]
+    pub cpp_settings: ::core::option::Option<CppSettings>,
+    /// Settings for PHP client libraries.
+    #[prost(message, optional, tag = "23")]
+    pub php_settings: ::core::option::Option<PhpSettings>,
+    /// Settings for Python client libraries.
+    #[prost(message, optional, tag = "24")]
+    pub python_settings: ::core::option::Option<PythonSettings>,
+    /// Settings for Node client libraries.
+    #[prost(message, optional, tag = "25")]
+    pub node_settings: ::core::option::Option<NodeSettings>,
+    /// Settings for .NET client libraries.
+    #[prost(message, optional, tag = "26")]
+    pub dotnet_settings: ::core::option::Option<DotnetSettings>,
+    /// Settings for Ruby client libraries.
+    #[prost(message, optional, tag = "27")]
+    pub ruby_settings: ::core::option::Option<RubySettings>,
+    /// Settings for Go client libraries.
+    #[prost(message, optional, tag = "28")]
+    pub go_settings: ::core::option::Option<GoSettings>,
+}
+/// This message configures the settings for publishing [Google Cloud Client
+/// libraries](<https://cloud.google.com/apis/docs/cloud-client-libraries>)
+/// generated from the service config.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Publishing {
+    /// A list of API method settings, e.g. the behavior for methods that use the
+    /// long-running operation pattern.
+    #[prost(message, repeated, tag = "2")]
+    pub method_settings: ::prost::alloc::vec::Vec<MethodSettings>,
+    /// Link to a place that API users can report issues.  Example:
+    /// <https://issuetracker.google.com/issues/new?component=190865&template=1161103>
+    #[prost(string, tag = "101")]
+    pub new_issue_uri: ::prost::alloc::string::String,
+    /// Link to product home page.  Example:
+    /// <https://cloud.google.com/asset-inventory/docs/overview>
+    #[prost(string, tag = "102")]
+    pub documentation_uri: ::prost::alloc::string::String,
+    /// Used as a tracking tag when collecting data about the APIs developer
+    /// relations artifacts like docs, packages delivered to package managers,
+    /// etc.  Example: "speech".
+    #[prost(string, tag = "103")]
+    pub api_short_name: ::prost::alloc::string::String,
+    /// GitHub label to apply to issues and pull requests opened for this API.
+    #[prost(string, tag = "104")]
+    pub github_label: ::prost::alloc::string::String,
+    /// GitHub teams to be added to CODEOWNERS in the directory in GitHub
+    /// containing source code for the client libraries for this API.
+    #[prost(string, repeated, tag = "105")]
+    pub codeowner_github_teams: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// A prefix used in sample code when demarking regions to be included in
+    /// documentation.
+    #[prost(string, tag = "106")]
+    pub doc_tag_prefix: ::prost::alloc::string::String,
+    /// For whom the client library is being published.
+    #[prost(enumeration = "ClientLibraryOrganization", tag = "107")]
+    pub organization: i32,
+    /// Client library settings.  If the same version string appears multiple
+    /// times in this list, then the last one wins.  Settings from earlier
+    /// settings with the same version string are discarded.
+    #[prost(message, repeated, tag = "109")]
+    pub library_settings: ::prost::alloc::vec::Vec<ClientLibrarySettings>,
+}
+/// Settings for Java client libraries.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct JavaSettings {
+    /// The package name to use in Java. Clobbers the java_package option
+    /// set in the protobuf. This should be used **only** by APIs
+    /// who have already set the language_settings.java.package_name" field
+    /// in gapic.yaml. API teams should use the protobuf java_package option
+    /// where possible.
+    ///
+    /// Example of a YAML configuration::
+    ///
+    ///  publishing:
+    ///    java_settings:
+    ///      library_package: com.google.cloud.pubsub.v1
+    #[prost(string, tag = "1")]
+    pub library_package: ::prost::alloc::string::String,
+    /// Configure the Java class name to use instead of the service's for its
+    /// corresponding generated GAPIC client. Keys are fully-qualified
+    /// service names as they appear in the protobuf (including the full
+    /// the language_settings.java.interface_names" field in gapic.yaml. API
+    /// teams should otherwise use the service name as it appears in the
+    /// protobuf.
+    ///
+    /// Example of a YAML configuration::
+    ///
+    ///  publishing:
+    ///    java_settings:
+    ///      service_class_names:
+    ///        - google.pubsub.v1.Publisher: TopicAdmin
+    ///        - google.pubsub.v1.Subscriber: SubscriptionAdmin
+    #[prost(map = "string, string", tag = "2")]
+    pub service_class_names:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// Some settings.
+    #[prost(message, optional, tag = "3")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for C++ client libraries.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CppSettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for Php client libraries.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PhpSettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for Python client libraries.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PythonSettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for Node client libraries.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NodeSettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for Dotnet client libraries.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DotnetSettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for Ruby client libraries.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RubySettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for Go client libraries.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GoSettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Describes the generator configuration for a method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MethodSettings {
+    /// The fully qualified name of the method, for which the options below apply.
+    /// This is used to find the method to apply the options.
+    #[prost(string, tag = "1")]
+    pub selector: ::prost::alloc::string::String,
+    /// Describes settings to use for long-running operations when generating
+    /// API methods for RPCs. Complements RPCs that use the annotations in
+    /// google/longrunning/operations.proto.
+    ///
+    /// Example of a YAML configuration::
+    ///
+    ///  publishing:
+    ///    method_behavior:
+    ///      - selector: CreateAdDomain
+    ///        long_running:
+    ///          initial_poll_delay:
+    ///            seconds: 60 # 1 minute
+    ///          poll_delay_multiplier: 1.5
+    ///          max_poll_delay:
+    ///            seconds: 360 # 6 minutes
+    ///          total_poll_timeout:
+    ///             seconds: 54000 # 90 minutes
+    #[prost(message, optional, tag = "2")]
+    pub long_running: ::core::option::Option<method_settings::LongRunning>,
+}
+/// Nested message and enum types in `MethodSettings`.
+pub mod method_settings {
+    /// Describes settings to use when generating API methods that use the
+    /// long-running operation pattern.
+    /// All default values below are from those used in the client library
+    /// generators (e.g.
+    /// \[Java\](<https://github.com/googleapis/gapic-generator-java/blob/04c2faa191a9b5a10b92392fe8482279c4404803/src/main/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposer.java>)).
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct LongRunning {
+        /// Initial delay after which the first poll request will be made.
+        /// Default value: 5 seconds.
+        #[prost(message, optional, tag = "1")]
+        pub initial_poll_delay: ::core::option::Option<::prost_types::Duration>,
+        /// Multiplier to gradually increase delay between subsequent polls until it
+        /// reaches max_poll_delay.
+        /// Default value: 1.5.
+        #[prost(float, tag = "2")]
+        pub poll_delay_multiplier: f32,
+        /// Maximum time between two subsequent poll requests.
+        /// Default value: 45 seconds.
+        #[prost(message, optional, tag = "3")]
+        pub max_poll_delay: ::core::option::Option<::prost_types::Duration>,
+        /// Total polling timeout.
+        /// Default value: 5 minutes.
+        #[prost(message, optional, tag = "4")]
+        pub total_poll_timeout: ::core::option::Option<::prost_types::Duration>,
+    }
+}
+/// The organization for which the client libraries are being published.
+/// Affects the url where generated docs are published, etc.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ClientLibraryOrganization {
+    /// Not useful.
+    Unspecified = 0,
+    /// Google Cloud Platform Org.
+    Cloud = 1,
+    /// Ads (Advertising) Org.
+    Ads = 2,
+    /// Photos Org.
+    Photos = 3,
+    /// Street View Org.
+    StreetView = 4,
+}
+/// To where should client libraries be published?
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ClientLibraryDestination {
+    /// Client libraries will neither be generated nor published to package
+    /// managers.
+    Unspecified = 0,
+    /// Generate the client library in a repo under github.com/googleapis,
+    /// but don't publish it to package managers.
+    Github = 10,
+    /// Publish the library to package managers like nuget.org and npmjs.com.
+    PackageManager = 20,
+}
 /// An indicator of the behavior of a given field (for example, that a field
 /// is required in requests, or given as output but ignored as input).
 /// This **does not** change the behavior in protocol buffers itself; it only
@@ -601,4 +905,437 @@ pub struct ResourceReference {
     ///     }
     #[prost(string, tag = "2")]
     pub child_type: ::prost::alloc::string::String,
+}
+/// Specifies the routing information that should be sent along with the request
+/// in the form of routing header.
+/// **NOTE:** All service configuration rules follow the "last one wins" order.
+///
+/// The examples below will apply to an RPC which has the following request type:
+///
+/// Message Definition:
+///
+///     message Request {
+///       // The name of the Table
+///       // Values can be of the following formats:
+///       // - `projects/<project>/tables/<table>`
+///       // - `projects/<project>/instances/<instance>/tables/<table>`
+///       // - `region/<region>/zones/<zone>/tables/<table>`
+///       string table_name = 1;
+///
+///       // This value specifies routing for replication.
+///       // It can be in the following formats:
+///       // - `profiles/<profile_id>`
+///       // - a legacy `profile_id` that can be any string
+///       string app_profile_id = 2;
+///     }
+///
+/// Example message:
+///
+///     {
+///       table_name: projects/proj_foo/instances/instance_bar/table/table_baz,
+///       app_profile_id: profiles/prof_qux
+///     }
+///
+/// The routing header consists of one or multiple key-value pairs. Every key
+/// and value must be percent-encoded, and joined together in the format of
+/// `key1=value1&key2=value2`.
+/// In the examples below I am skipping the percent-encoding for readablity.
+///
+/// Example 1
+///
+/// Extracting a field from the request to put into the routing header
+/// unchanged, with the key equal to the field name.
+///
+/// annotation:
+///
+///     option (google.api.routing) = {
+///       // Take the `app_profile_id`.
+///       routing_parameters {
+///         field: "app_profile_id"
+///       }
+///     };
+///
+/// result:
+///
+///     x-goog-request-params: app_profile_id=profiles/prof_qux
+///
+/// Example 2
+///
+/// Extracting a field from the request to put into the routing header
+/// unchanged, with the key different from the field name.
+///
+/// annotation:
+///
+///     option (google.api.routing) = {
+///       // Take the `app_profile_id`, but name it `routing_id` in the header.
+///       routing_parameters {
+///         field: "app_profile_id"
+///         path_template: "{routing_id=**}"
+///       }
+///     };
+///
+/// result:
+///
+///     x-goog-request-params: routing_id=profiles/prof_qux
+///
+/// Example 3
+///
+/// Extracting a field from the request to put into the routing
+/// header, while matching a path template syntax on the field's value.
+///
+/// NB: it is more useful to send nothing than to send garbage for the purpose
+/// of dynamic routing, since garbage pollutes cache. Thus the matching.
+///
+/// Sub-example 3a
+///
+/// The field matches the template.
+///
+/// annotation:
+///
+///     option (google.api.routing) = {
+///       // Take the `table_name`, if it's well-formed (with project-based
+///       // syntax).
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "{table_name=projects/*/instances/*/**}"
+///       }
+///     };
+///
+/// result:
+///
+///     x-goog-request-params:
+///     table_name=projects/proj_foo/instances/instance_bar/table/table_baz
+///
+/// Sub-example 3b
+///
+/// The field does not match the template.
+///
+/// annotation:
+///
+///     option (google.api.routing) = {
+///       // Take the `table_name`, if it's well-formed (with region-based
+///       // syntax).
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "{table_name=regions/*/zones/*/**}"
+///       }
+///     };
+///
+/// result:
+///
+///     <no routing header will be sent>
+///
+/// Sub-example 3c
+///
+/// Multiple alternative conflictingly named path templates are
+/// specified. The one that matches is used to construct the header.
+///
+/// annotation:
+///
+///     option (google.api.routing) = {
+///       // Take the `table_name`, if it's well-formed, whether
+///       // using the region- or projects-based syntax.
+///
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "{table_name=regions/*/zones/*/**}"
+///       }
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "{table_name=projects/*/instances/*/**}"
+///       }
+///     };
+///
+/// result:
+///
+///     x-goog-request-params:
+///     table_name=projects/proj_foo/instances/instance_bar/table/table_baz
+///
+/// Example 4
+///
+/// Extracting a single routing header key-value pair by matching a
+/// template syntax on (a part of) a single request field.
+///
+/// annotation:
+///
+///     option (google.api.routing) = {
+///       // Take just the project id from the `table_name` field.
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "{routing_id=projects/*}/**"
+///       }
+///     };
+///
+/// result:
+///
+///     x-goog-request-params: routing_id=projects/proj_foo
+///
+/// Example 5
+///
+/// Extracting a single routing header key-value pair by matching
+/// several conflictingly named path templates on (parts of) a single request
+/// field. The last template to match "wins" the conflict.
+///
+/// annotation:
+///
+///     option (google.api.routing) = {
+///       // If the `table_name` does not have instances information,
+///       // take just the project id for routing.
+///       // Otherwise take project + instance.
+///
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "{routing_id=projects/*}/**"
+///       }
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "{routing_id=projects/*/instances/*}/**"
+///       }
+///     };
+///
+/// result:
+///
+///     x-goog-request-params:
+///     routing_id=projects/proj_foo/instances/instance_bar
+///
+/// Example 6
+///
+/// Extracting multiple routing header key-value pairs by matching
+/// several non-conflicting path templates on (parts of) a single request field.
+///
+/// Sub-example 6a
+///
+/// Make the templates strict, so that if the `table_name` does not
+/// have an instance information, nothing is sent.
+///
+/// annotation:
+///
+///     option (google.api.routing) = {
+///       // The routing code needs two keys instead of one composite
+///       // but works only for the tables with the "project-instance" name
+///       // syntax.
+///
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "{project_id=projects/*}/instances/*/**"
+///       }
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "projects/*/{instance_id=instances/*}/**"
+///       }
+///     };
+///
+/// result:
+///
+///     x-goog-request-params:
+///     project_id=projects/proj_foo&instance_id=instances/instance_bar
+///
+/// Sub-example 6b
+///
+/// Make the templates loose, so that if the `table_name` does not
+/// have an instance information, just the project id part is sent.
+///
+/// annotation:
+///
+///     option (google.api.routing) = {
+///       // The routing code wants two keys instead of one composite
+///       // but will work with just the `project_id` for tables without
+///       // an instance in the `table_name`.
+///
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "{project_id=projects/*}/**"
+///       }
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "projects/*/{instance_id=instances/*}/**"
+///       }
+///     };
+///
+/// result (is the same as 6a for our example message because it has the instance
+/// information):
+///
+///     x-goog-request-params:
+///     project_id=projects/proj_foo&instance_id=instances/instance_bar
+///
+/// Example 7
+///
+/// Extracting multiple routing header key-value pairs by matching
+/// several path templates on multiple request fields.
+///
+/// NB: note that here there is no way to specify sending nothing if one of the
+/// fields does not match its template. E.g. if the `table_name` is in the wrong
+/// format, the `project_id` will not be sent, but the `routing_id` will be.
+/// The backend routing code has to be aware of that and be prepared to not
+/// receive a full complement of keys if it expects multiple.
+///
+/// annotation:
+///
+///     option (google.api.routing) = {
+///       // The routing needs both `project_id` and `routing_id`
+///       // (from the `app_profile_id` field) for routing.
+///
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "{project_id=projects/*}/**"
+///       }
+///       routing_parameters {
+///         field: "app_profile_id"
+///         path_template: "{routing_id=**}"
+///       }
+///     };
+///
+/// result:
+///
+///     x-goog-request-params:
+///     project_id=projects/proj_foo&routing_id=profiles/prof_qux
+///
+/// Example 8
+///
+/// Extracting a single routing header key-value pair by matching
+/// several conflictingly named path templates on several request fields. The
+/// last template to match "wins" the conflict.
+///
+/// annotation:
+///
+///     option (google.api.routing) = {
+///       // The `routing_id` can be a project id or a region id depending on
+///       // the table name format, but only if the `app_profile_id` is not set.
+///       // If `app_profile_id` is set it should be used instead.
+///
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "{routing_id=projects/*}/**"
+///       }
+///       routing_parameters {
+///          field: "table_name"
+///          path_template: "{routing_id=regions/*}/**"
+///       }
+///       routing_parameters {
+///         field: "app_profile_id"
+///         path_template: "{routing_id=**}"
+///       }
+///     };
+///
+/// result:
+///
+///     x-goog-request-params: routing_id=profiles/prof_qux
+///
+/// Example 9
+///
+/// Bringing it all together.
+///
+/// annotation:
+///
+///     option (google.api.routing) = {
+///       // For routing both `table_location` and a `routing_id` are needed.
+///       //
+///       // table_location can be either an instance id or a region+zone id.
+///       //
+///       // For `routing_id`, take the value of `app_profile_id`
+///       // - If it's in the format `profiles/<profile_id>`, send
+///       // just the `<profile_id>` part.
+///       // - If it's any other literal, send it as is.
+///       // If the `app_profile_id` is empty, and the `table_name` starts with
+///       // the project_id, send that instead.
+///
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "projects/*/{table_location=instances/*}/tables/*"
+///       }
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "{table_location=regions/*/zones/*}/tables/*"
+///       }
+///       routing_parameters {
+///         field: "table_name"
+///         path_template: "{routing_id=projects/*}/**"
+///       }
+///       routing_parameters {
+///         field: "app_profile_id"
+///         path_template: "{routing_id=**}"
+///       }
+///       routing_parameters {
+///         field: "app_profile_id"
+///         path_template: "profiles/{routing_id=*}"
+///       }
+///     };
+///
+/// result:
+///
+///     x-goog-request-params:
+///     table_location=instances/instance_bar&routing_id=prof_qux
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RoutingRule {
+    /// A collection of Routing Parameter specifications.
+    /// **NOTE:** If multiple Routing Parameters describe the same key
+    /// (via the `path_template` field or via the `field` field when
+    /// `path_template` is not provided), "last one wins" rule
+    /// determines which Parameter gets used.
+    /// See the examples for more details.
+    #[prost(message, repeated, tag = "2")]
+    pub routing_parameters: ::prost::alloc::vec::Vec<RoutingParameter>,
+}
+/// A projection from an input message to the GRPC or REST header.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RoutingParameter {
+    /// A request field to extract the header key-value pair from.
+    #[prost(string, tag = "1")]
+    pub field: ::prost::alloc::string::String,
+    /// A pattern matching the key-value field. Optional.
+    /// If not specified, the whole field specified in the `field` field will be
+    /// taken as value, and its name used as key. If specified, it MUST contain
+    /// exactly one named segment (along with any number of unnamed segments) The
+    /// pattern will be matched over the field specified in the `field` field, then
+    /// if the match is successful:
+    /// - the name of the single named segment will be used as a header name,
+    /// - the match value of the segment will be used as a header value;
+    /// if the match is NOT successful, nothing will be sent.
+    ///
+    /// Example:
+    ///
+    ///               -- This is a field in the request message
+    ///              |   that the header value will be extracted from.
+    ///              |
+    ///              |                     -- This is the key name in the
+    ///              |                    |   routing header.
+    ///              V                    |
+    ///     field: "table_name"           v
+    ///     path_template: "projects/*/{table_location=instances/*}/tables/*"
+    ///                                                ^            ^
+    ///                                                |            |
+    ///       In the {} brackets is the pattern that --             |
+    ///       specifies what to extract from the                    |
+    ///       field as a value to be sent.                          |
+    ///                                                             |
+    ///      The string in the field must match the whole pattern --
+    ///      before brackets, inside brackets, after brackets.
+    ///
+    /// When looking at this specific example, we can see that:
+    /// - A key-value pair with the key `table_location`
+    ///   and the value matching `instances/*` should be added
+    ///   to the x-goog-request-params routing header.
+    /// - The value is extracted from the request message's `table_name` field
+    ///   if it matches the full pattern specified:
+    ///   `projects/*/instances/*/tables/*`.
+    ///
+    /// **NB:** If the `path_template` field is not provided, the key name is
+    /// equal to the field name, and the whole field should be sent as a value.
+    /// This makes the pattern for the field and the value functionally equivalent
+    /// to `**`, and the configuration
+    ///
+    ///     {
+    ///       field: "table_name"
+    ///     }
+    ///
+    /// is a functionally equivalent shorthand to:
+    ///
+    ///     {
+    ///       field: "table_name"
+    ///       path_template: "{table_name=**}"
+    ///     }
+    ///
+    /// See Example 1 for more details.
+    #[prost(string, tag = "2")]
+    pub path_template: ::prost::alloc::string::String,
 }

--- a/src/generated/google.bigtable.admin.v2.rs
+++ b/src/generated/google.bigtable.admin.v2.rs
@@ -1,0 +1,1656 @@
+/// Encapsulates progress related information for a Cloud Bigtable long
+/// running operation.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OperationProgress {
+    /// Percent completion of the operation.
+    /// Values are between 0 and 100 inclusive.
+    #[prost(int32, tag = "1")]
+    pub progress_percent: i32,
+    /// Time the request was received.
+    #[prost(message, optional, tag = "2")]
+    pub start_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// If set, the time at which this operation failed or was completed
+    /// successfully.
+    #[prost(message, optional, tag = "3")]
+    pub end_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+/// Storage media types for persisting Bigtable data.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum StorageType {
+    /// The user did not specify a storage type.
+    Unspecified = 0,
+    /// Flash (SSD) storage should be used.
+    Ssd = 1,
+    /// Magnetic drive (HDD) storage should be used.
+    Hdd = 2,
+}
+/// Information about a table restore.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RestoreInfo {
+    /// The type of the restore source.
+    #[prost(enumeration = "RestoreSourceType", tag = "1")]
+    pub source_type: i32,
+    /// Information about the source used to restore the table.
+    #[prost(oneof = "restore_info::SourceInfo", tags = "2")]
+    pub source_info: ::core::option::Option<restore_info::SourceInfo>,
+}
+/// Nested message and enum types in `RestoreInfo`.
+pub mod restore_info {
+    /// Information about the source used to restore the table.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum SourceInfo {
+        /// Information about the backup used to restore the table. The backup
+        /// may no longer exist.
+        #[prost(message, tag = "2")]
+        BackupInfo(super::BackupInfo),
+    }
+}
+/// A collection of user data indexed by row, column, and timestamp.
+/// Each table is served using the resources of its parent cluster.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Table {
+    /// The unique name of the table. Values are of the form
+    /// `projects/{project}/instances/{instance}/tables/\[_a-zA-Z0-9][-_.a-zA-Z0-9\]*`.
+    /// Views: `NAME_ONLY`, `SCHEMA_VIEW`, `REPLICATION_VIEW`, `FULL`
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Output only. Map from cluster ID to per-cluster table state.
+    /// If it could not be determined whether or not the table has data in a
+    /// particular cluster (for example, if its zone is unavailable), then
+    /// there will be an entry for the cluster with UNKNOWN `replication_status`.
+    /// Views: `REPLICATION_VIEW`, `ENCRYPTION_VIEW`, `FULL`
+    #[prost(map = "string, message", tag = "2")]
+    pub cluster_states:
+        ::std::collections::HashMap<::prost::alloc::string::String, table::ClusterState>,
+    /// The column families configured for this table, mapped by column family ID.
+    /// Views: `SCHEMA_VIEW`, `FULL`
+    #[prost(map = "string, message", tag = "3")]
+    pub column_families: ::std::collections::HashMap<::prost::alloc::string::String, ColumnFamily>,
+    /// Immutable. The granularity (i.e. `MILLIS`) at which timestamps are stored in this
+    /// table. Timestamps not matching the granularity will be rejected.
+    /// If unspecified at creation time, the value will be set to `MILLIS`.
+    /// Views: `SCHEMA_VIEW`, `FULL`.
+    #[prost(enumeration = "table::TimestampGranularity", tag = "4")]
+    pub granularity: i32,
+    /// Output only. If this table was restored from another data source (e.g. a backup), this
+    /// field will be populated with information about the restore.
+    #[prost(message, optional, tag = "6")]
+    pub restore_info: ::core::option::Option<RestoreInfo>,
+    /// Set to true to make the table protected against data loss. i.e. deleting
+    /// the following resources through Admin APIs are prohibited:
+    ///   - The table.
+    ///   - The column families in the table.
+    ///   - The instance containing the table.
+    /// Note one can still delete the data stored in the table through Data APIs.
+    #[prost(bool, tag = "9")]
+    pub deletion_protection: bool,
+}
+/// Nested message and enum types in `Table`.
+pub mod table {
+    /// The state of a table's data in a particular cluster.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ClusterState {
+        /// Output only. The state of replication for the table in this cluster.
+        #[prost(enumeration = "cluster_state::ReplicationState", tag = "1")]
+        pub replication_state: i32,
+        /// Output only. The encryption information for the table in this cluster.
+        /// If the encryption key protecting this resource is customer managed, then
+        /// its version can be rotated in Cloud Key Management Service (Cloud KMS).
+        /// The primary version of the key and its status will be reflected here when
+        /// changes propagate from Cloud KMS.
+        #[prost(message, repeated, tag = "2")]
+        pub encryption_info: ::prost::alloc::vec::Vec<super::EncryptionInfo>,
+    }
+    /// Nested message and enum types in `ClusterState`.
+    pub mod cluster_state {
+        /// Table replication states.
+        #[derive(
+            Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration,
+        )]
+        #[repr(i32)]
+        pub enum ReplicationState {
+            /// The replication state of the table is unknown in this cluster.
+            StateNotKnown = 0,
+            /// The cluster was recently created, and the table must finish copying
+            /// over pre-existing data from other clusters before it can begin
+            /// receiving live replication updates and serving Data API requests.
+            Initializing = 1,
+            /// The table is temporarily unable to serve Data API requests from this
+            /// cluster due to planned internal maintenance.
+            PlannedMaintenance = 2,
+            /// The table is temporarily unable to serve Data API requests from this
+            /// cluster due to unplanned or emergency maintenance.
+            UnplannedMaintenance = 3,
+            /// The table can serve Data API requests from this cluster. Depending on
+            /// replication delay, reads may not immediately reflect the state of the
+            /// table in other clusters.
+            Ready = 4,
+            /// The table is fully created and ready for use after a restore, and is
+            /// being optimized for performance. When optimizations are complete, the
+            /// table will transition to `READY` state.
+            ReadyOptimizing = 5,
+        }
+    }
+    /// Possible timestamp granularities to use when keeping multiple versions
+    /// of data in a table.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum TimestampGranularity {
+        /// The user did not specify a granularity. Should not be returned.
+        /// When specified during table creation, MILLIS will be used.
+        Unspecified = 0,
+        /// The table keeps data versioned at a granularity of 1ms.
+        Millis = 1,
+    }
+    /// Defines a view over a table's fields.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum View {
+        /// Uses the default view for each method as documented in its request.
+        Unspecified = 0,
+        /// Only populates `name`.
+        NameOnly = 1,
+        /// Only populates `name` and fields related to the table's schema.
+        SchemaView = 2,
+        /// Only populates `name` and fields related to the table's replication
+        /// state.
+        ReplicationView = 3,
+        /// Only populates `name` and fields related to the table's encryption state.
+        EncryptionView = 5,
+        /// Populates all fields.
+        Full = 4,
+    }
+}
+/// A set of columns within a table which share a common configuration.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ColumnFamily {
+    /// Garbage collection rule specified as a protobuf.
+    /// Must serialize to at most 500 bytes.
+    ///
+    /// NOTE: Garbage collection executes opportunistically in the background, and
+    /// so it's possible for reads to return a cell even if it matches the active
+    /// GC expression for its family.
+    #[prost(message, optional, tag = "1")]
+    pub gc_rule: ::core::option::Option<GcRule>,
+}
+/// Rule for determining which cells to delete during garbage collection.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GcRule {
+    /// Garbage collection rules.
+    #[prost(oneof = "gc_rule::Rule", tags = "1, 2, 3, 4")]
+    pub rule: ::core::option::Option<gc_rule::Rule>,
+}
+/// Nested message and enum types in `GcRule`.
+pub mod gc_rule {
+    /// A GcRule which deletes cells matching all of the given rules.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Intersection {
+        /// Only delete cells which would be deleted by every element of `rules`.
+        #[prost(message, repeated, tag = "1")]
+        pub rules: ::prost::alloc::vec::Vec<super::GcRule>,
+    }
+    /// A GcRule which deletes cells matching any of the given rules.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Union {
+        /// Delete cells which would be deleted by any element of `rules`.
+        #[prost(message, repeated, tag = "1")]
+        pub rules: ::prost::alloc::vec::Vec<super::GcRule>,
+    }
+    /// Garbage collection rules.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Rule {
+        /// Delete all cells in a column except the most recent N.
+        #[prost(int32, tag = "1")]
+        MaxNumVersions(i32),
+        /// Delete cells in a column older than the given age.
+        /// Values must be at least one millisecond, and will be truncated to
+        /// microsecond granularity.
+        #[prost(message, tag = "2")]
+        MaxAge(::prost_types::Duration),
+        /// Delete cells that would be deleted by every nested rule.
+        #[prost(message, tag = "3")]
+        Intersection(Intersection),
+        /// Delete cells that would be deleted by any nested rule.
+        #[prost(message, tag = "4")]
+        Union(Union),
+    }
+}
+/// Encryption information for a given resource.
+/// If this resource is protected with customer managed encryption, the in-use
+/// Cloud Key Management Service (Cloud KMS) key version is specified along with
+/// its status.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EncryptionInfo {
+    /// Output only. The type of encryption used to protect this resource.
+    #[prost(enumeration = "encryption_info::EncryptionType", tag = "3")]
+    pub encryption_type: i32,
+    /// Output only. The status of encrypt/decrypt calls on underlying data for this resource.
+    /// Regardless of status, the existing data is always encrypted at rest.
+    #[prost(message, optional, tag = "4")]
+    pub encryption_status: ::core::option::Option<super::super::super::rpc::Status>,
+    /// Output only. The version of the Cloud KMS key specified in the parent cluster that is
+    /// in use for the data underlying this table.
+    #[prost(string, tag = "2")]
+    pub kms_key_version: ::prost::alloc::string::String,
+}
+/// Nested message and enum types in `EncryptionInfo`.
+pub mod encryption_info {
+    /// Possible encryption types for a resource.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum EncryptionType {
+        /// Encryption type was not specified, though data at rest remains encrypted.
+        Unspecified = 0,
+        /// The data backing this resource is encrypted at rest with a key that is
+        /// fully managed by Google. No key version or status will be populated.
+        /// This is the default state.
+        GoogleDefaultEncryption = 1,
+        /// The data backing this resource is encrypted at rest with a key that is
+        /// managed by the customer.
+        /// The in-use version of the key and its status are populated for
+        /// CMEK-protected tables.
+        /// CMEK-protected backups are pinned to the key version that was in use at
+        /// the time the backup was taken. This key version is populated but its
+        /// status is not tracked and is reported as `UNKNOWN`.
+        CustomerManagedEncryption = 2,
+    }
+}
+/// A snapshot of a table at a particular time. A snapshot can be used as a
+/// checkpoint for data restoration or a data source for a new table.
+///
+/// Note: This is a private alpha release of Cloud Bigtable snapshots. This
+/// feature is not currently available to most Cloud Bigtable customers. This
+/// feature might be changed in backward-incompatible ways and is not recommended
+/// for production use. It is not subject to any SLA or deprecation policy.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Snapshot {
+    /// Output only. The unique name of the snapshot.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Output only. The source table at the time the snapshot was taken.
+    #[prost(message, optional, tag = "2")]
+    pub source_table: ::core::option::Option<Table>,
+    /// Output only. The size of the data in the source table at the time the
+    /// snapshot was taken. In some cases, this value may be computed
+    /// asynchronously via a background process and a placeholder of 0 will be used
+    /// in the meantime.
+    #[prost(int64, tag = "3")]
+    pub data_size_bytes: i64,
+    /// Output only. The time when the snapshot is created.
+    #[prost(message, optional, tag = "4")]
+    pub create_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// Output only. The time when the snapshot will be deleted. The maximum amount
+    /// of time a snapshot can stay active is 365 days. If 'ttl' is not specified,
+    /// the default maximum of 365 days will be used.
+    #[prost(message, optional, tag = "5")]
+    pub delete_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// Output only. The current state of the snapshot.
+    #[prost(enumeration = "snapshot::State", tag = "6")]
+    pub state: i32,
+    /// Output only. Description of the snapshot.
+    #[prost(string, tag = "7")]
+    pub description: ::prost::alloc::string::String,
+}
+/// Nested message and enum types in `Snapshot`.
+pub mod snapshot {
+    /// Possible states of a snapshot.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum State {
+        /// The state of the snapshot could not be determined.
+        NotKnown = 0,
+        /// The snapshot has been successfully created and can serve all requests.
+        Ready = 1,
+        /// The snapshot is currently being created, and may be destroyed if the
+        /// creation process encounters an error. A snapshot may not be restored to a
+        /// table while it is being created.
+        Creating = 2,
+    }
+}
+/// A backup of a Cloud Bigtable table.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Backup {
+    /// A globally unique identifier for the backup which cannot be
+    /// changed. Values are of the form
+    /// `projects/{project}/instances/{instance}/clusters/{cluster}/
+    ///    backups/\[_a-zA-Z0-9][-_.a-zA-Z0-9\]*`
+    /// The final segment of the name must be between 1 and 50 characters
+    /// in length.
+    ///
+    /// The backup is stored in the cluster identified by the prefix of the backup
+    /// name of the form
+    /// `projects/{project}/instances/{instance}/clusters/{cluster}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Required. Immutable. Name of the table from which this backup was created. This needs
+    /// to be in the same instance as the backup. Values are of the form
+    /// `projects/{project}/instances/{instance}/tables/{source_table}`.
+    #[prost(string, tag = "2")]
+    pub source_table: ::prost::alloc::string::String,
+    /// Required. The expiration time of the backup, with microseconds
+    /// granularity that must be at least 6 hours and at most 30 days
+    /// from the time the request is received. Once the `expire_time`
+    /// has passed, Cloud Bigtable will delete the backup and free the
+    /// resources used by the backup.
+    #[prost(message, optional, tag = "3")]
+    pub expire_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// Output only. `start_time` is the time that the backup was started
+    /// (i.e. approximately the time the
+    /// \[CreateBackup][google.bigtable.admin.v2.BigtableTableAdmin.CreateBackup\] request is received).  The
+    /// row data in this backup will be no older than this timestamp.
+    #[prost(message, optional, tag = "4")]
+    pub start_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// Output only. `end_time` is the time that the backup was finished. The row
+    /// data in the backup will be no newer than this timestamp.
+    #[prost(message, optional, tag = "5")]
+    pub end_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// Output only. Size of the backup in bytes.
+    #[prost(int64, tag = "6")]
+    pub size_bytes: i64,
+    /// Output only. The current state of the backup.
+    #[prost(enumeration = "backup::State", tag = "7")]
+    pub state: i32,
+    /// Output only. The encryption information for the backup.
+    #[prost(message, optional, tag = "9")]
+    pub encryption_info: ::core::option::Option<EncryptionInfo>,
+}
+/// Nested message and enum types in `Backup`.
+pub mod backup {
+    /// Indicates the current state of the backup.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum State {
+        /// Not specified.
+        Unspecified = 0,
+        /// The pending backup is still being created. Operations on the
+        /// backup may fail with `FAILED_PRECONDITION` in this state.
+        Creating = 1,
+        /// The backup is complete and ready for use.
+        Ready = 2,
+    }
+}
+/// Information about a backup.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BackupInfo {
+    /// Output only. Name of the backup.
+    #[prost(string, tag = "1")]
+    pub backup: ::prost::alloc::string::String,
+    /// Output only. The time that the backup was started. Row data in the backup
+    /// will be no older than this timestamp.
+    #[prost(message, optional, tag = "2")]
+    pub start_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// Output only. This time that the backup was finished. Row data in the
+    /// backup will be no newer than this timestamp.
+    #[prost(message, optional, tag = "3")]
+    pub end_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// Output only. Name of the table the backup was created from.
+    #[prost(string, tag = "4")]
+    pub source_table: ::prost::alloc::string::String,
+}
+/// Indicates the type of the restore source.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum RestoreSourceType {
+    /// No restore associated.
+    Unspecified = 0,
+    /// A backup was used as the source of the restore.
+    Backup = 1,
+}
+/// The request for
+/// \[RestoreTable][google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RestoreTableRequest {
+    /// Required. The name of the instance in which to create the restored
+    /// table. This instance must be in the same project as the source backup.
+    /// Values are of the form `projects/<project>/instances/<instance>`.
+    #[prost(string, tag = "1")]
+    pub parent: ::prost::alloc::string::String,
+    /// Required. The id of the table to create and restore to. This
+    /// table must not already exist. The `table_id` appended to
+    /// `parent` forms the full table name of the form
+    /// `projects/<project>/instances/<instance>/tables/<table_id>`.
+    #[prost(string, tag = "2")]
+    pub table_id: ::prost::alloc::string::String,
+    /// Required. The source from which to restore.
+    #[prost(oneof = "restore_table_request::Source", tags = "3")]
+    pub source: ::core::option::Option<restore_table_request::Source>,
+}
+/// Nested message and enum types in `RestoreTableRequest`.
+pub mod restore_table_request {
+    /// Required. The source from which to restore.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Source {
+        /// Name of the backup from which to restore.  Values are of the form
+        /// `projects/<project>/instances/<instance>/clusters/<cluster>/backups/<backup>`.
+        #[prost(string, tag = "3")]
+        Backup(::prost::alloc::string::String),
+    }
+}
+/// Metadata type for the long-running operation returned by
+/// \[RestoreTable][google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RestoreTableMetadata {
+    /// Name of the table being created and restored to.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// The type of the restore source.
+    #[prost(enumeration = "RestoreSourceType", tag = "2")]
+    pub source_type: i32,
+    /// If exists, the name of the long-running operation that will be used to
+    /// track the post-restore optimization process to optimize the performance of
+    /// the restored table. The metadata type of the long-running operation is
+    /// \[OptimizeRestoreTableMetadata][\]. The response type is
+    /// \[Empty][google.protobuf.Empty\]. This long-running operation may be
+    /// automatically created by the system if applicable after the
+    /// RestoreTable long-running operation completes successfully. This operation
+    /// may not be created if the table is already optimized or the restore was
+    /// not successful.
+    #[prost(string, tag = "4")]
+    pub optimize_table_operation_name: ::prost::alloc::string::String,
+    /// The progress of the \[RestoreTable][google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable\]
+    /// operation.
+    #[prost(message, optional, tag = "5")]
+    pub progress: ::core::option::Option<OperationProgress>,
+    /// Information about the source used to restore the table, as specified by
+    /// `source` in \[RestoreTableRequest][google.bigtable.admin.v2.RestoreTableRequest\].
+    #[prost(oneof = "restore_table_metadata::SourceInfo", tags = "3")]
+    pub source_info: ::core::option::Option<restore_table_metadata::SourceInfo>,
+}
+/// Nested message and enum types in `RestoreTableMetadata`.
+pub mod restore_table_metadata {
+    /// Information about the source used to restore the table, as specified by
+    /// `source` in \[RestoreTableRequest][google.bigtable.admin.v2.RestoreTableRequest\].
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum SourceInfo {
+        #[prost(message, tag = "3")]
+        BackupInfo(super::BackupInfo),
+    }
+}
+/// Metadata type for the long-running operation used to track the progress
+/// of optimizations performed on a newly restored table. This long-running
+/// operation is automatically created by the system after the successful
+/// completion of a table restore, and cannot be cancelled.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OptimizeRestoredTableMetadata {
+    /// Name of the restored table being optimized.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// The progress of the post-restore optimizations.
+    #[prost(message, optional, tag = "2")]
+    pub progress: ::core::option::Option<OperationProgress>,
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.CreateTable][google.bigtable.admin.v2.BigtableTableAdmin.CreateTable\]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateTableRequest {
+    /// Required. The unique name of the instance in which to create the table.
+    /// Values are of the form `projects/{project}/instances/{instance}`.
+    #[prost(string, tag = "1")]
+    pub parent: ::prost::alloc::string::String,
+    /// Required. The name by which the new table should be referred to within the parent
+    /// instance, e.g., `foobar` rather than `{parent}/tables/foobar`.
+    /// Maximum 50 characters.
+    #[prost(string, tag = "2")]
+    pub table_id: ::prost::alloc::string::String,
+    /// Required. The Table to create.
+    #[prost(message, optional, tag = "3")]
+    pub table: ::core::option::Option<Table>,
+    /// The optional list of row keys that will be used to initially split the
+    /// table into several tablets (tablets are similar to HBase regions).
+    /// Given two split keys, `s1` and `s2`, three tablets will be created,
+    /// spanning the key ranges: `[, s1), [s1, s2), [s2, )`.
+    ///
+    /// Example:
+    ///
+    /// * Row keys := `["a", "apple", "custom", "customer_1", "customer_2",`
+    ///                `"other", "zz"]`
+    /// * initial_split_keys := `["apple", "customer_1", "customer_2", "other"]`
+    /// * Key assignment:
+    ///     - Tablet 1 `[, apple)                => {"a"}.`
+    ///     - Tablet 2 `[apple, customer_1)      => {"apple", "custom"}.`
+    ///     - Tablet 3 `[customer_1, customer_2) => {"customer_1"}.`
+    ///     - Tablet 4 `[customer_2, other)      => {"customer_2"}.`
+    ///     - Tablet 5 `[other, )                => {"other", "zz"}.`
+    #[prost(message, repeated, tag = "4")]
+    pub initial_splits: ::prost::alloc::vec::Vec<create_table_request::Split>,
+}
+/// Nested message and enum types in `CreateTableRequest`.
+pub mod create_table_request {
+    /// An initial split point for a newly created table.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Split {
+        /// Row key to use as an initial tablet boundary.
+        #[prost(bytes = "bytes", tag = "1")]
+        pub key: ::prost::bytes::Bytes,
+    }
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.CreateTableFromSnapshot][google.bigtable.admin.v2.BigtableTableAdmin.CreateTableFromSnapshot\]
+///
+/// Note: This is a private alpha release of Cloud Bigtable snapshots. This
+/// feature is not currently available to most Cloud Bigtable customers. This
+/// feature might be changed in backward-incompatible ways and is not recommended
+/// for production use. It is not subject to any SLA or deprecation policy.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateTableFromSnapshotRequest {
+    /// Required. The unique name of the instance in which to create the table.
+    /// Values are of the form `projects/{project}/instances/{instance}`.
+    #[prost(string, tag = "1")]
+    pub parent: ::prost::alloc::string::String,
+    /// Required. The name by which the new table should be referred to within the parent
+    /// instance, e.g., `foobar` rather than `{parent}/tables/foobar`.
+    #[prost(string, tag = "2")]
+    pub table_id: ::prost::alloc::string::String,
+    /// Required. The unique name of the snapshot from which to restore the table. The
+    /// snapshot and the table must be in the same instance.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}`.
+    #[prost(string, tag = "3")]
+    pub source_snapshot: ::prost::alloc::string::String,
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange][google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange\]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DropRowRangeRequest {
+    /// Required. The unique name of the table on which to drop a range of rows.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/tables/{table}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Delete all rows or by prefix.
+    #[prost(oneof = "drop_row_range_request::Target", tags = "2, 3")]
+    pub target: ::core::option::Option<drop_row_range_request::Target>,
+}
+/// Nested message and enum types in `DropRowRangeRequest`.
+pub mod drop_row_range_request {
+    /// Delete all rows or by prefix.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Target {
+        /// Delete all rows that start with this row key prefix. Prefix cannot be
+        /// zero length.
+        #[prost(bytes, tag = "2")]
+        RowKeyPrefix(::prost::bytes::Bytes),
+        /// Delete all rows in the table. Setting this to false is a no-op.
+        #[prost(bool, tag = "3")]
+        DeleteAllDataFromTable(bool),
+    }
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.ListTables][google.bigtable.admin.v2.BigtableTableAdmin.ListTables\]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListTablesRequest {
+    /// Required. The unique name of the instance for which tables should be listed.
+    /// Values are of the form `projects/{project}/instances/{instance}`.
+    #[prost(string, tag = "1")]
+    pub parent: ::prost::alloc::string::String,
+    /// The view to be applied to the returned tables' fields.
+    /// Only NAME_ONLY view (default) and REPLICATION_VIEW are supported.
+    #[prost(enumeration = "table::View", tag = "2")]
+    pub view: i32,
+    /// Maximum number of results per page.
+    ///
+    /// A page_size of zero lets the server choose the number of items to return.
+    /// A page_size which is strictly positive will return at most that many items.
+    /// A negative page_size will cause an error.
+    ///
+    /// Following the first request, subsequent paginated calls are not required
+    /// to pass a page_size. If a page_size is set in subsequent calls, it must
+    /// match the page_size given in the first request.
+    #[prost(int32, tag = "4")]
+    pub page_size: i32,
+    /// The value of `next_page_token` returned by a previous call.
+    #[prost(string, tag = "3")]
+    pub page_token: ::prost::alloc::string::String,
+}
+/// Response message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.ListTables][google.bigtable.admin.v2.BigtableTableAdmin.ListTables\]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListTablesResponse {
+    /// The tables present in the requested instance.
+    #[prost(message, repeated, tag = "1")]
+    pub tables: ::prost::alloc::vec::Vec<Table>,
+    /// Set if not all tables could be returned in a single response.
+    /// Pass this value to `page_token` in another request to get the next
+    /// page of results.
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.GetTable][google.bigtable.admin.v2.BigtableTableAdmin.GetTable\]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetTableRequest {
+    /// Required. The unique name of the requested table.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/tables/{table}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// The view to be applied to the returned table's fields.
+    /// Defaults to `SCHEMA_VIEW` if unspecified.
+    #[prost(enumeration = "table::View", tag = "2")]
+    pub view: i32,
+}
+/// The request for
+/// \[UpdateTable][google.bigtable.admin.v2.BigtableTableAdmin.UpdateTable\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateTableRequest {
+    /// Required. The table to update.
+    /// The table's `name` field is used to identify the table to update.
+    #[prost(message, optional, tag = "1")]
+    pub table: ::core::option::Option<Table>,
+    /// Required. The list of fields to update.
+    /// A mask specifying which fields (e.g. `deletion_protection`) in the `table`
+    /// field should be updated. This mask is relative to the `table` field, not to
+    /// the request message. The wildcard (*) path is currently not supported.
+    /// Currently UpdateTable is only supported for the following field:
+    ///  * `deletion_protection`
+    /// If `column_families` is set in `update_mask`, it will return an
+    /// UNIMPLEMENTED error.
+    #[prost(message, optional, tag = "2")]
+    pub update_mask: ::core::option::Option<::prost_types::FieldMask>,
+}
+/// Metadata type for the operation returned by
+/// \[UpdateTable][google.bigtable.admin.v2.BigtableTableAdmin.UpdateTable\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateTableMetadata {
+    /// The name of the table being updated.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// The time at which this operation started.
+    #[prost(message, optional, tag = "2")]
+    pub start_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// If set, the time at which this operation finished or was canceled.
+    #[prost(message, optional, tag = "3")]
+    pub end_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.DeleteTable][google.bigtable.admin.v2.BigtableTableAdmin.DeleteTable\]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteTableRequest {
+    /// Required. The unique name of the table to be deleted.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/tables/{table}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.UndeleteTable][google.bigtable.admin.v2.BigtableTableAdmin.UndeleteTable\]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UndeleteTableRequest {
+    /// Required. The unique name of the table to be restored.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/tables/{table}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// Metadata type for the operation returned by
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.UndeleteTable][google.bigtable.admin.v2.BigtableTableAdmin.UndeleteTable\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UndeleteTableMetadata {
+    /// The name of the table being restored.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// The time at which this operation started.
+    #[prost(message, optional, tag = "2")]
+    pub start_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// If set, the time at which this operation finished or was cancelled.
+    #[prost(message, optional, tag = "3")]
+    pub end_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.ModifyColumnFamilies][google.bigtable.admin.v2.BigtableTableAdmin.ModifyColumnFamilies\]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ModifyColumnFamiliesRequest {
+    /// Required. The unique name of the table whose families should be modified.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/tables/{table}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Required. Modifications to be atomically applied to the specified table's families.
+    /// Entries are applied in order, meaning that earlier modifications can be
+    /// masked by later ones (in the case of repeated updates to the same family,
+    /// for example).
+    #[prost(message, repeated, tag = "2")]
+    pub modifications: ::prost::alloc::vec::Vec<modify_column_families_request::Modification>,
+}
+/// Nested message and enum types in `ModifyColumnFamiliesRequest`.
+pub mod modify_column_families_request {
+    /// A create, update, or delete of a particular column family.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Modification {
+        /// The ID of the column family to be modified.
+        #[prost(string, tag = "1")]
+        pub id: ::prost::alloc::string::String,
+        /// Column family modifications.
+        #[prost(oneof = "modification::Mod", tags = "2, 3, 4")]
+        pub r#mod: ::core::option::Option<modification::Mod>,
+    }
+    /// Nested message and enum types in `Modification`.
+    pub mod modification {
+        /// Column family modifications.
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub enum Mod {
+            /// Create a new column family with the specified schema, or fail if
+            /// one already exists with the given ID.
+            #[prost(message, tag = "2")]
+            Create(super::super::ColumnFamily),
+            /// Update an existing column family to the specified schema, or fail
+            /// if no column family exists with the given ID.
+            #[prost(message, tag = "3")]
+            Update(super::super::ColumnFamily),
+            /// Drop (delete) the column family with the given ID, or fail if no such
+            /// family exists.
+            #[prost(bool, tag = "4")]
+            Drop(bool),
+        }
+    }
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.GenerateConsistencyToken][google.bigtable.admin.v2.BigtableTableAdmin.GenerateConsistencyToken\]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenerateConsistencyTokenRequest {
+    /// Required. The unique name of the Table for which to create a consistency token.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/tables/{table}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// Response message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.GenerateConsistencyToken][google.bigtable.admin.v2.BigtableTableAdmin.GenerateConsistencyToken\]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenerateConsistencyTokenResponse {
+    /// The generated consistency token.
+    #[prost(string, tag = "1")]
+    pub consistency_token: ::prost::alloc::string::String,
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency][google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency\]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CheckConsistencyRequest {
+    /// Required. The unique name of the Table for which to check replication consistency.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/tables/{table}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Required. The token created using GenerateConsistencyToken for the Table.
+    #[prost(string, tag = "2")]
+    pub consistency_token: ::prost::alloc::string::String,
+}
+/// Response message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency][google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency\]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CheckConsistencyResponse {
+    /// True only if the token is consistent. A token is consistent if replication
+    /// has caught up with the restrictions specified in the request.
+    #[prost(bool, tag = "1")]
+    pub consistent: bool,
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.SnapshotTable][google.bigtable.admin.v2.BigtableTableAdmin.SnapshotTable\]
+///
+/// Note: This is a private alpha release of Cloud Bigtable snapshots. This
+/// feature is not currently available to most Cloud Bigtable customers. This
+/// feature might be changed in backward-incompatible ways and is not recommended
+/// for production use. It is not subject to any SLA or deprecation policy.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SnapshotTableRequest {
+    /// Required. The unique name of the table to have the snapshot taken.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/tables/{table}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Required. The name of the cluster where the snapshot will be created in.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/clusters/{cluster}`.
+    #[prost(string, tag = "2")]
+    pub cluster: ::prost::alloc::string::String,
+    /// Required. The ID by which the new snapshot should be referred to within the parent
+    /// cluster, e.g., `mysnapshot` of the form: `\[_a-zA-Z0-9][-_.a-zA-Z0-9\]*`
+    /// rather than
+    /// `projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/mysnapshot`.
+    #[prost(string, tag = "3")]
+    pub snapshot_id: ::prost::alloc::string::String,
+    /// The amount of time that the new snapshot can stay active after it is
+    /// created. Once 'ttl' expires, the snapshot will get deleted. The maximum
+    /// amount of time a snapshot can stay active is 7 days. If 'ttl' is not
+    /// specified, the default value of 24 hours will be used.
+    #[prost(message, optional, tag = "4")]
+    pub ttl: ::core::option::Option<::prost_types::Duration>,
+    /// Description of the snapshot.
+    #[prost(string, tag = "5")]
+    pub description: ::prost::alloc::string::String,
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.GetSnapshot][google.bigtable.admin.v2.BigtableTableAdmin.GetSnapshot\]
+///
+/// Note: This is a private alpha release of Cloud Bigtable snapshots. This
+/// feature is not currently available to most Cloud Bigtable customers. This
+/// feature might be changed in backward-incompatible ways and is not recommended
+/// for production use. It is not subject to any SLA or deprecation policy.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetSnapshotRequest {
+    /// Required. The unique name of the requested snapshot.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.ListSnapshots][google.bigtable.admin.v2.BigtableTableAdmin.ListSnapshots\]
+///
+/// Note: This is a private alpha release of Cloud Bigtable snapshots. This
+/// feature is not currently available to most Cloud Bigtable customers. This
+/// feature might be changed in backward-incompatible ways and is not recommended
+/// for production use. It is not subject to any SLA or deprecation policy.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListSnapshotsRequest {
+    /// Required. The unique name of the cluster for which snapshots should be listed.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/clusters/{cluster}`.
+    /// Use `{cluster} = '-'` to list snapshots for all clusters in an instance,
+    /// e.g., `projects/{project}/instances/{instance}/clusters/-`.
+    #[prost(string, tag = "1")]
+    pub parent: ::prost::alloc::string::String,
+    /// The maximum number of snapshots to return per page.
+    /// CURRENTLY UNIMPLEMENTED AND IGNORED.
+    #[prost(int32, tag = "2")]
+    pub page_size: i32,
+    /// The value of `next_page_token` returned by a previous call.
+    #[prost(string, tag = "3")]
+    pub page_token: ::prost::alloc::string::String,
+}
+/// Response message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.ListSnapshots][google.bigtable.admin.v2.BigtableTableAdmin.ListSnapshots\]
+///
+/// Note: This is a private alpha release of Cloud Bigtable snapshots. This
+/// feature is not currently available to most Cloud Bigtable customers. This
+/// feature might be changed in backward-incompatible ways and is not recommended
+/// for production use. It is not subject to any SLA or deprecation policy.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListSnapshotsResponse {
+    /// The snapshots present in the requested cluster.
+    #[prost(message, repeated, tag = "1")]
+    pub snapshots: ::prost::alloc::vec::Vec<Snapshot>,
+    /// Set if not all snapshots could be returned in a single response.
+    /// Pass this value to `page_token` in another request to get the next
+    /// page of results.
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+}
+/// Request message for
+/// \[google.bigtable.admin.v2.BigtableTableAdmin.DeleteSnapshot][google.bigtable.admin.v2.BigtableTableAdmin.DeleteSnapshot\]
+///
+/// Note: This is a private alpha release of Cloud Bigtable snapshots. This
+/// feature is not currently available to most Cloud Bigtable customers. This
+/// feature might be changed in backward-incompatible ways and is not recommended
+/// for production use. It is not subject to any SLA or deprecation policy.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteSnapshotRequest {
+    /// Required. The unique name of the snapshot to be deleted.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// The metadata for the Operation returned by SnapshotTable.
+///
+/// Note: This is a private alpha release of Cloud Bigtable snapshots. This
+/// feature is not currently available to most Cloud Bigtable customers. This
+/// feature might be changed in backward-incompatible ways and is not recommended
+/// for production use. It is not subject to any SLA or deprecation policy.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SnapshotTableMetadata {
+    /// The request that prompted the initiation of this SnapshotTable operation.
+    #[prost(message, optional, tag = "1")]
+    pub original_request: ::core::option::Option<SnapshotTableRequest>,
+    /// The time at which the original request was received.
+    #[prost(message, optional, tag = "2")]
+    pub request_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// The time at which the operation failed or was completed successfully.
+    #[prost(message, optional, tag = "3")]
+    pub finish_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+/// The metadata for the Operation returned by CreateTableFromSnapshot.
+///
+/// Note: This is a private alpha release of Cloud Bigtable snapshots. This
+/// feature is not currently available to most Cloud Bigtable customers. This
+/// feature might be changed in backward-incompatible ways and is not recommended
+/// for production use. It is not subject to any SLA or deprecation policy.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateTableFromSnapshotMetadata {
+    /// The request that prompted the initiation of this CreateTableFromSnapshot
+    /// operation.
+    #[prost(message, optional, tag = "1")]
+    pub original_request: ::core::option::Option<CreateTableFromSnapshotRequest>,
+    /// The time at which the original request was received.
+    #[prost(message, optional, tag = "2")]
+    pub request_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// The time at which the operation failed or was completed successfully.
+    #[prost(message, optional, tag = "3")]
+    pub finish_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+/// The request for \[CreateBackup][google.bigtable.admin.v2.BigtableTableAdmin.CreateBackup\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateBackupRequest {
+    /// Required. This must be one of the clusters in the instance in which this
+    /// table is located. The backup will be stored in this cluster. Values are
+    /// of the form `projects/{project}/instances/{instance}/clusters/{cluster}`.
+    #[prost(string, tag = "1")]
+    pub parent: ::prost::alloc::string::String,
+    /// Required. The id of the backup to be created. The `backup_id` along with
+    /// the parent `parent` are combined as {parent}/backups/{backup_id} to create
+    /// the full backup name, of the form:
+    /// `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup_id}`.
+    /// This string must be between 1 and 50 characters in length and match the
+    /// regex \[_a-zA-Z0-9][-_.a-zA-Z0-9\]*.
+    #[prost(string, tag = "2")]
+    pub backup_id: ::prost::alloc::string::String,
+    /// Required. The backup to create.
+    #[prost(message, optional, tag = "3")]
+    pub backup: ::core::option::Option<Backup>,
+}
+/// Metadata type for the operation returned by
+/// \[CreateBackup][google.bigtable.admin.v2.BigtableTableAdmin.CreateBackup\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateBackupMetadata {
+    /// The name of the backup being created.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// The name of the table the backup is created from.
+    #[prost(string, tag = "2")]
+    pub source_table: ::prost::alloc::string::String,
+    /// The time at which this operation started.
+    #[prost(message, optional, tag = "3")]
+    pub start_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// If set, the time at which this operation finished or was cancelled.
+    #[prost(message, optional, tag = "4")]
+    pub end_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+/// The request for \[UpdateBackup][google.bigtable.admin.v2.BigtableTableAdmin.UpdateBackup\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateBackupRequest {
+    /// Required. The backup to update. `backup.name`, and the fields to be updated
+    /// as specified by `update_mask` are required. Other fields are ignored.
+    /// Update is only supported for the following fields:
+    ///  * `backup.expire_time`.
+    #[prost(message, optional, tag = "1")]
+    pub backup: ::core::option::Option<Backup>,
+    /// Required. A mask specifying which fields (e.g. `expire_time`) in the
+    /// Backup resource should be updated. This mask is relative to the Backup
+    /// resource, not to the request message. The field mask must always be
+    /// specified; this prevents any future fields from being erased accidentally
+    /// by clients that do not know about them.
+    #[prost(message, optional, tag = "2")]
+    pub update_mask: ::core::option::Option<::prost_types::FieldMask>,
+}
+/// The request for \[GetBackup][google.bigtable.admin.v2.BigtableTableAdmin.GetBackup\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetBackupRequest {
+    /// Required. Name of the backup.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// The request for \[DeleteBackup][google.bigtable.admin.v2.BigtableTableAdmin.DeleteBackup\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteBackupRequest {
+    /// Required. Name of the backup to delete.
+    /// Values are of the form
+    /// `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// The request for \[ListBackups][google.bigtable.admin.v2.BigtableTableAdmin.ListBackups\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListBackupsRequest {
+    /// Required. The cluster to list backups from.  Values are of the
+    /// form `projects/{project}/instances/{instance}/clusters/{cluster}`.
+    /// Use `{cluster} = '-'` to list backups for all clusters in an instance,
+    /// e.g., `projects/{project}/instances/{instance}/clusters/-`.
+    #[prost(string, tag = "1")]
+    pub parent: ::prost::alloc::string::String,
+    /// A filter expression that filters backups listed in the response.
+    /// The expression must specify the field name, a comparison operator,
+    /// and the value that you want to use for filtering. The value must be a
+    /// string, a number, or a boolean. The comparison operator must be
+    /// <, >, <=, >=, !=, =, or :. Colon ':' represents a HAS operator which is
+    /// roughly synonymous with equality. Filter rules are case insensitive.
+    ///
+    /// The fields eligible for filtering are:
+    ///   * `name`
+    ///   * `source_table`
+    ///   * `state`
+    ///   * `start_time` (and values are of the format YYYY-MM-DDTHH:MM:SSZ)
+    ///   * `end_time` (and values are of the format YYYY-MM-DDTHH:MM:SSZ)
+    ///   * `expire_time` (and values are of the format YYYY-MM-DDTHH:MM:SSZ)
+    ///   * `size_bytes`
+    ///
+    /// To filter on multiple expressions, provide each separate expression within
+    /// parentheses. By default, each expression is an AND expression. However,
+    /// you can include AND, OR, and NOT expressions explicitly.
+    ///
+    /// Some examples of using filters are:
+    ///
+    ///   * `name:"exact"` --> The backup's name is the string "exact".
+    ///   * `name:howl` --> The backup's name contains the string "howl".
+    ///   * `source_table:prod`
+    ///          --> The source_table's name contains the string "prod".
+    ///   * `state:CREATING` --> The backup is pending creation.
+    ///   * `state:READY` --> The backup is fully created and ready for use.
+    ///   * `(name:howl) AND (start_time < \"2018-03-28T14:50:00Z\")`
+    ///          --> The backup name contains the string "howl" and start_time
+    ///              of the backup is before 2018-03-28T14:50:00Z.
+    ///   * `size_bytes > 10000000000` --> The backup's size is greater than 10GB
+    #[prost(string, tag = "2")]
+    pub filter: ::prost::alloc::string::String,
+    /// An expression for specifying the sort order of the results of the request.
+    /// The string value should specify one or more fields in \[Backup][google.bigtable.admin.v2.Backup\]. The full
+    /// syntax is described at <https://aip.dev/132#ordering.>
+    ///
+    /// Fields supported are:
+    ///    * name
+    ///    * source_table
+    ///    * expire_time
+    ///    * start_time
+    ///    * end_time
+    ///    * size_bytes
+    ///    * state
+    ///
+    /// For example, "start_time". The default sorting order is ascending.
+    /// To specify descending order for the field, a suffix " desc" should
+    /// be appended to the field name. For example, "start_time desc".
+    /// Redundant space characters in the syntax are insigificant.
+    ///
+    /// If order_by is empty, results will be sorted by `start_time` in descending
+    /// order starting from the most recently created backup.
+    #[prost(string, tag = "3")]
+    pub order_by: ::prost::alloc::string::String,
+    /// Number of backups to be returned in the response. If 0 or
+    /// less, defaults to the server's maximum allowed page size.
+    #[prost(int32, tag = "4")]
+    pub page_size: i32,
+    /// If non-empty, `page_token` should contain a
+    /// \[next_page_token][google.bigtable.admin.v2.ListBackupsResponse.next_page_token\] from a
+    /// previous \[ListBackupsResponse][google.bigtable.admin.v2.ListBackupsResponse\] to the same `parent` and with the same
+    /// `filter`.
+    #[prost(string, tag = "5")]
+    pub page_token: ::prost::alloc::string::String,
+}
+/// The response for \[ListBackups][google.bigtable.admin.v2.BigtableTableAdmin.ListBackups\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListBackupsResponse {
+    /// The list of matching backups.
+    #[prost(message, repeated, tag = "1")]
+    pub backups: ::prost::alloc::vec::Vec<Backup>,
+    /// `next_page_token` can be sent in a subsequent
+    /// \[ListBackups][google.bigtable.admin.v2.BigtableTableAdmin.ListBackups\] call to fetch more
+    /// of the matching backups.
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+}
+#[doc = r" Generated client implementations."]
+pub mod bigtable_table_admin_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[doc = " Service for creating, configuring, and deleting Cloud Bigtable tables."]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = " Provides access to the table schemas only, not the data stored within"]
+    #[doc = " the tables."]
+    #[derive(Debug, Clone)]
+    pub struct BigtableTableAdminClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl BigtableTableAdminClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> BigtableTableAdminClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> BigtableTableAdminClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            BigtableTableAdminClient::new(InterceptedService::new(inner, interceptor))
+        }
+        #[doc = r" Compress requests with `gzip`."]
+        #[doc = r""]
+        #[doc = r" This requires the server to support it otherwise it might respond with an"]
+        #[doc = r" error."]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        #[doc = r" Enable decompressing responses with `gzip`."]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        #[doc = " Creates a new table in the specified instance."]
+        #[doc = " The table can be created with a full set of initial column families,"]
+        #[doc = " specified in the request."]
+        pub async fn create_table(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateTableRequest>,
+        ) -> Result<tonic::Response<super::Table>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/CreateTable",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Creates a new table from the specified snapshot. The target table must"]
+        #[doc = " not exist. The snapshot and the table must be in the same instance."]
+        #[doc = ""]
+        #[doc = " Note: This is a private alpha release of Cloud Bigtable snapshots. This"]
+        #[doc = " feature is not currently available to most Cloud Bigtable customers. This"]
+        #[doc = " feature might be changed in backward-incompatible ways and is not"]
+        #[doc = " recommended for production use. It is not subject to any SLA or deprecation"]
+        #[doc = " policy."]
+        pub async fn create_table_from_snapshot(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateTableFromSnapshotRequest>,
+        ) -> Result<
+            tonic::Response<super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/CreateTableFromSnapshot",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Lists all tables served from a specified instance."]
+        pub async fn list_tables(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListTablesRequest>,
+        ) -> Result<tonic::Response<super::ListTablesResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/ListTables",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Gets metadata information about the specified table."]
+        pub async fn get_table(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetTableRequest>,
+        ) -> Result<tonic::Response<super::Table>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/GetTable",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Updates a specified table."]
+        pub async fn update_table(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpdateTableRequest>,
+        ) -> Result<
+            tonic::Response<super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/UpdateTable",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Permanently deletes a specified table and all of its data."]
+        pub async fn delete_table(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteTableRequest>,
+        ) -> Result<tonic::Response<()>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/DeleteTable",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Restores a specified table which was accidentally deleted."]
+        pub async fn undelete_table(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UndeleteTableRequest>,
+        ) -> Result<
+            tonic::Response<super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/UndeleteTable",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Performs a series of column family modifications on the specified table."]
+        #[doc = " Either all or none of the modifications will occur before this method"]
+        #[doc = " returns, but data requests received prior to that point may see a table"]
+        #[doc = " where only some modifications have taken effect."]
+        pub async fn modify_column_families(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ModifyColumnFamiliesRequest>,
+        ) -> Result<tonic::Response<super::Table>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/ModifyColumnFamilies",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Permanently drop/delete a row range from a specified table. The request can"]
+        #[doc = " specify whether to delete all rows in a table, or only those that match a"]
+        #[doc = " particular prefix."]
+        pub async fn drop_row_range(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DropRowRangeRequest>,
+        ) -> Result<tonic::Response<()>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/DropRowRange",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Generates a consistency token for a Table, which can be used in"]
+        #[doc = " CheckConsistency to check whether mutations to the table that finished"]
+        #[doc = " before this call started have been replicated. The tokens will be available"]
+        #[doc = " for 90 days."]
+        pub async fn generate_consistency_token(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GenerateConsistencyTokenRequest>,
+        ) -> Result<tonic::Response<super::GenerateConsistencyTokenResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/GenerateConsistencyToken",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Checks replication consistency based on a consistency token, that is, if"]
+        #[doc = " replication has caught up based on the conditions specified in the token"]
+        #[doc = " and the check request."]
+        pub async fn check_consistency(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CheckConsistencyRequest>,
+        ) -> Result<tonic::Response<super::CheckConsistencyResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/CheckConsistency",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Creates a new snapshot in the specified cluster from the specified"]
+        #[doc = " source table. The cluster and the table must be in the same instance."]
+        #[doc = ""]
+        #[doc = " Note: This is a private alpha release of Cloud Bigtable snapshots. This"]
+        #[doc = " feature is not currently available to most Cloud Bigtable customers. This"]
+        #[doc = " feature might be changed in backward-incompatible ways and is not"]
+        #[doc = " recommended for production use. It is not subject to any SLA or deprecation"]
+        #[doc = " policy."]
+        pub async fn snapshot_table(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SnapshotTableRequest>,
+        ) -> Result<
+            tonic::Response<super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/SnapshotTable",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Gets metadata information about the specified snapshot."]
+        #[doc = ""]
+        #[doc = " Note: This is a private alpha release of Cloud Bigtable snapshots. This"]
+        #[doc = " feature is not currently available to most Cloud Bigtable customers. This"]
+        #[doc = " feature might be changed in backward-incompatible ways and is not"]
+        #[doc = " recommended for production use. It is not subject to any SLA or deprecation"]
+        #[doc = " policy."]
+        pub async fn get_snapshot(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetSnapshotRequest>,
+        ) -> Result<tonic::Response<super::Snapshot>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/GetSnapshot",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Lists all snapshots associated with the specified cluster."]
+        #[doc = ""]
+        #[doc = " Note: This is a private alpha release of Cloud Bigtable snapshots. This"]
+        #[doc = " feature is not currently available to most Cloud Bigtable customers. This"]
+        #[doc = " feature might be changed in backward-incompatible ways and is not"]
+        #[doc = " recommended for production use. It is not subject to any SLA or deprecation"]
+        #[doc = " policy."]
+        pub async fn list_snapshots(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListSnapshotsRequest>,
+        ) -> Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/ListSnapshots",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Permanently deletes the specified snapshot."]
+        #[doc = ""]
+        #[doc = " Note: This is a private alpha release of Cloud Bigtable snapshots. This"]
+        #[doc = " feature is not currently available to most Cloud Bigtable customers. This"]
+        #[doc = " feature might be changed in backward-incompatible ways and is not"]
+        #[doc = " recommended for production use. It is not subject to any SLA or deprecation"]
+        #[doc = " policy."]
+        pub async fn delete_snapshot(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteSnapshotRequest>,
+        ) -> Result<tonic::Response<()>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/DeleteSnapshot",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Starts creating a new Cloud Bigtable Backup.  The returned backup"]
+        #[doc = " [long-running operation][google.longrunning.Operation] can be used to"]
+        #[doc = " track creation of the backup. The"]
+        #[doc = " [metadata][google.longrunning.Operation.metadata] field type is"]
+        #[doc = " [CreateBackupMetadata][google.bigtable.admin.v2.CreateBackupMetadata]. The"]
+        #[doc = " [response][google.longrunning.Operation.response] field type is"]
+        #[doc = " [Backup][google.bigtable.admin.v2.Backup], if successful. Cancelling the returned operation will stop the"]
+        #[doc = " creation and delete the backup."]
+        pub async fn create_backup(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateBackupRequest>,
+        ) -> Result<
+            tonic::Response<super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/CreateBackup",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Gets metadata on a pending or completed Cloud Bigtable Backup."]
+        pub async fn get_backup(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetBackupRequest>,
+        ) -> Result<tonic::Response<super::Backup>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/GetBackup",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Updates a pending or completed Cloud Bigtable Backup."]
+        pub async fn update_backup(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpdateBackupRequest>,
+        ) -> Result<tonic::Response<super::Backup>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/UpdateBackup",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Deletes a pending or completed Cloud Bigtable backup."]
+        pub async fn delete_backup(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteBackupRequest>,
+        ) -> Result<tonic::Response<()>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/DeleteBackup",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Lists Cloud Bigtable backups. Returns both completed and pending"]
+        #[doc = " backups."]
+        pub async fn list_backups(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListBackupsRequest>,
+        ) -> Result<tonic::Response<super::ListBackupsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/ListBackups",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Create a new table by restoring from a completed backup. The new table"]
+        #[doc = " must be in the same project as the instance containing the backup.  The"]
+        #[doc = " returned table [long-running operation][google.longrunning.Operation] can"]
+        #[doc = " be used to track the progress of the operation, and to cancel it.  The"]
+        #[doc = " [metadata][google.longrunning.Operation.metadata] field type is"]
+        #[doc = " [RestoreTableMetadata][google.bigtable.admin.RestoreTableMetadata].  The"]
+        #[doc = " [response][google.longrunning.Operation.response] type is"]
+        #[doc = " [Table][google.bigtable.admin.v2.Table], if successful."]
+        pub async fn restore_table(
+            &mut self,
+            request: impl tonic::IntoRequest<super::RestoreTableRequest>,
+        ) -> Result<
+            tonic::Response<super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/RestoreTable",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Gets the access control policy for a Table or Backup resource."]
+        #[doc = " Returns an empty policy if the resource exists but does not have a policy"]
+        #[doc = " set."]
+        pub async fn get_iam_policy(
+            &mut self,
+            request: impl tonic::IntoRequest<super::super::super::super::iam::v1::GetIamPolicyRequest>,
+        ) -> Result<tonic::Response<super::super::super::super::iam::v1::Policy>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/GetIamPolicy",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Sets the access control policy on a Table or Backup resource."]
+        #[doc = " Replaces any existing policy."]
+        pub async fn set_iam_policy(
+            &mut self,
+            request: impl tonic::IntoRequest<super::super::super::super::iam::v1::SetIamPolicyRequest>,
+        ) -> Result<tonic::Response<super::super::super::super::iam::v1::Policy>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/SetIamPolicy",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Returns permissions that the caller has on the specified Table or Backup resource."]
+        pub async fn test_iam_permissions(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::super::super::super::iam::v1::TestIamPermissionsRequest,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::super::iam::v1::TestIamPermissionsResponse>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.admin.v2.BigtableTableAdmin/TestIamPermissions",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}

--- a/src/generated/google.bigtable.v2.rs
+++ b/src/generated/google.bigtable.v2.rs
@@ -1,0 +1,1175 @@
+/// Specifies the complete (requested) contents of a single row of a table.
+/// Rows which exceed 256MiB in size cannot be read in full.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Row {
+    /// The unique key which identifies this row within its table. This is the same
+    /// key that's used to identify the row in, for example, a MutateRowRequest.
+    /// May contain any non-empty byte string up to 4KiB in length.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub key: ::prost::bytes::Bytes,
+    /// May be empty, but only if the entire row is empty.
+    /// The mutual ordering of column families is not specified.
+    #[prost(message, repeated, tag = "2")]
+    pub families: ::prost::alloc::vec::Vec<Family>,
+}
+/// Specifies (some of) the contents of a single row/column family intersection
+/// of a table.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Family {
+    /// The unique key which identifies this family within its row. This is the
+    /// same key that's used to identify the family in, for example, a RowFilter
+    /// which sets its "family_name_regex_filter" field.
+    /// Must match `\[-_.a-zA-Z0-9\]+`, except that AggregatingRowProcessors may
+    /// produce cells in a sentinel family with an empty name.
+    /// Must be no greater than 64 characters in length.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Must not be empty. Sorted in order of increasing "qualifier".
+    #[prost(message, repeated, tag = "2")]
+    pub columns: ::prost::alloc::vec::Vec<Column>,
+}
+/// Specifies (some of) the contents of a single row/column intersection of a
+/// table.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Column {
+    /// The unique key which identifies this column within its family. This is the
+    /// same key that's used to identify the column in, for example, a RowFilter
+    /// which sets its `column_qualifier_regex_filter` field.
+    /// May contain any byte string, including the empty string, up to 16kiB in
+    /// length.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub qualifier: ::prost::bytes::Bytes,
+    /// Must not be empty. Sorted in order of decreasing "timestamp_micros".
+    #[prost(message, repeated, tag = "2")]
+    pub cells: ::prost::alloc::vec::Vec<Cell>,
+}
+/// Specifies (some of) the contents of a single row/column/timestamp of a table.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Cell {
+    /// The cell's stored timestamp, which also uniquely identifies it within
+    /// its column.
+    /// Values are always expressed in microseconds, but individual tables may set
+    /// a coarser granularity to further restrict the allowed values. For
+    /// example, a table which specifies millisecond granularity will only allow
+    /// values of `timestamp_micros` which are multiples of 1000.
+    #[prost(int64, tag = "1")]
+    pub timestamp_micros: i64,
+    /// The value stored in the cell.
+    /// May contain any byte string, including the empty string, up to 100MiB in
+    /// length.
+    #[prost(bytes = "bytes", tag = "2")]
+    pub value: ::prost::bytes::Bytes,
+    /// Labels applied to the cell by a \[RowFilter][google.bigtable.v2.RowFilter\].
+    #[prost(string, repeated, tag = "3")]
+    pub labels: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Specifies a contiguous range of rows.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RowRange {
+    /// The row key at which to start the range.
+    /// If neither field is set, interpreted as the empty string, inclusive.
+    #[prost(oneof = "row_range::StartKey", tags = "1, 2")]
+    pub start_key: ::core::option::Option<row_range::StartKey>,
+    /// The row key at which to end the range.
+    /// If neither field is set, interpreted as the infinite row key, exclusive.
+    #[prost(oneof = "row_range::EndKey", tags = "3, 4")]
+    pub end_key: ::core::option::Option<row_range::EndKey>,
+}
+/// Nested message and enum types in `RowRange`.
+pub mod row_range {
+    /// The row key at which to start the range.
+    /// If neither field is set, interpreted as the empty string, inclusive.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum StartKey {
+        /// Used when giving an inclusive lower bound for the range.
+        #[prost(bytes, tag = "1")]
+        StartKeyClosed(::prost::bytes::Bytes),
+        /// Used when giving an exclusive lower bound for the range.
+        #[prost(bytes, tag = "2")]
+        StartKeyOpen(::prost::bytes::Bytes),
+    }
+    /// The row key at which to end the range.
+    /// If neither field is set, interpreted as the infinite row key, exclusive.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum EndKey {
+        /// Used when giving an exclusive upper bound for the range.
+        #[prost(bytes, tag = "3")]
+        EndKeyOpen(::prost::bytes::Bytes),
+        /// Used when giving an inclusive upper bound for the range.
+        #[prost(bytes, tag = "4")]
+        EndKeyClosed(::prost::bytes::Bytes),
+    }
+}
+/// Specifies a non-contiguous set of rows.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RowSet {
+    /// Single rows included in the set.
+    #[prost(bytes = "bytes", repeated, tag = "1")]
+    pub row_keys: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    /// Contiguous row ranges included in the set.
+    #[prost(message, repeated, tag = "2")]
+    pub row_ranges: ::prost::alloc::vec::Vec<RowRange>,
+}
+/// Specifies a contiguous range of columns within a single column family.
+/// The range spans from &lt;column_family&gt;:&lt;start_qualifier&gt; to
+/// &lt;column_family&gt;:&lt;end_qualifier&gt;, where both bounds can be either
+/// inclusive or exclusive.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ColumnRange {
+    /// The name of the column family within which this range falls.
+    #[prost(string, tag = "1")]
+    pub family_name: ::prost::alloc::string::String,
+    /// The column qualifier at which to start the range (within `column_family`).
+    /// If neither field is set, interpreted as the empty string, inclusive.
+    #[prost(oneof = "column_range::StartQualifier", tags = "2, 3")]
+    pub start_qualifier: ::core::option::Option<column_range::StartQualifier>,
+    /// The column qualifier at which to end the range (within `column_family`).
+    /// If neither field is set, interpreted as the infinite string, exclusive.
+    #[prost(oneof = "column_range::EndQualifier", tags = "4, 5")]
+    pub end_qualifier: ::core::option::Option<column_range::EndQualifier>,
+}
+/// Nested message and enum types in `ColumnRange`.
+pub mod column_range {
+    /// The column qualifier at which to start the range (within `column_family`).
+    /// If neither field is set, interpreted as the empty string, inclusive.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum StartQualifier {
+        /// Used when giving an inclusive lower bound for the range.
+        #[prost(bytes, tag = "2")]
+        StartQualifierClosed(::prost::bytes::Bytes),
+        /// Used when giving an exclusive lower bound for the range.
+        #[prost(bytes, tag = "3")]
+        StartQualifierOpen(::prost::bytes::Bytes),
+    }
+    /// The column qualifier at which to end the range (within `column_family`).
+    /// If neither field is set, interpreted as the infinite string, exclusive.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum EndQualifier {
+        /// Used when giving an inclusive upper bound for the range.
+        #[prost(bytes, tag = "4")]
+        EndQualifierClosed(::prost::bytes::Bytes),
+        /// Used when giving an exclusive upper bound for the range.
+        #[prost(bytes, tag = "5")]
+        EndQualifierOpen(::prost::bytes::Bytes),
+    }
+}
+/// Specified a contiguous range of microsecond timestamps.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TimestampRange {
+    /// Inclusive lower bound. If left empty, interpreted as 0.
+    #[prost(int64, tag = "1")]
+    pub start_timestamp_micros: i64,
+    /// Exclusive upper bound. If left empty, interpreted as infinity.
+    #[prost(int64, tag = "2")]
+    pub end_timestamp_micros: i64,
+}
+/// Specifies a contiguous range of raw byte values.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValueRange {
+    /// The value at which to start the range.
+    /// If neither field is set, interpreted as the empty string, inclusive.
+    #[prost(oneof = "value_range::StartValue", tags = "1, 2")]
+    pub start_value: ::core::option::Option<value_range::StartValue>,
+    /// The value at which to end the range.
+    /// If neither field is set, interpreted as the infinite string, exclusive.
+    #[prost(oneof = "value_range::EndValue", tags = "3, 4")]
+    pub end_value: ::core::option::Option<value_range::EndValue>,
+}
+/// Nested message and enum types in `ValueRange`.
+pub mod value_range {
+    /// The value at which to start the range.
+    /// If neither field is set, interpreted as the empty string, inclusive.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum StartValue {
+        /// Used when giving an inclusive lower bound for the range.
+        #[prost(bytes, tag = "1")]
+        StartValueClosed(::prost::bytes::Bytes),
+        /// Used when giving an exclusive lower bound for the range.
+        #[prost(bytes, tag = "2")]
+        StartValueOpen(::prost::bytes::Bytes),
+    }
+    /// The value at which to end the range.
+    /// If neither field is set, interpreted as the infinite string, exclusive.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum EndValue {
+        /// Used when giving an inclusive upper bound for the range.
+        #[prost(bytes, tag = "3")]
+        EndValueClosed(::prost::bytes::Bytes),
+        /// Used when giving an exclusive upper bound for the range.
+        #[prost(bytes, tag = "4")]
+        EndValueOpen(::prost::bytes::Bytes),
+    }
+}
+/// Takes a row as input and produces an alternate view of the row based on
+/// specified rules. For example, a RowFilter might trim down a row to include
+/// just the cells from columns matching a given regular expression, or might
+/// return all the cells of a row but not their values. More complicated filters
+/// can be composed out of these components to express requests such as, "within
+/// every column of a particular family, give just the two most recent cells
+/// which are older than timestamp X."
+///
+/// There are two broad categories of RowFilters (true filters and transformers),
+/// as well as two ways to compose simple filters into more complex ones
+/// (chains and interleaves). They work as follows:
+///
+/// * True filters alter the input row by excluding some of its cells wholesale
+/// from the output row. An example of a true filter is the `value_regex_filter`,
+/// which excludes cells whose values don't match the specified pattern. All
+/// regex true filters use RE2 syntax (<https://github.com/google/re2/wiki/Syntax>)
+/// in raw byte mode (RE2::Latin1), and are evaluated as full matches. An
+/// important point to keep in mind is that `RE2(.)` is equivalent by default to
+/// `RE2(\[^\n\])`, meaning that it does not match newlines. When attempting to
+/// match an arbitrary byte, you should therefore use the escape sequence `\C`,
+/// which may need to be further escaped as `\\C` in your client language.
+///
+/// * Transformers alter the input row by changing the values of some of its
+/// cells in the output, without excluding them completely. Currently, the only
+/// supported transformer is the `strip_value_transformer`, which replaces every
+/// cell's value with the empty string.
+///
+/// * Chains and interleaves are described in more detail in the
+/// RowFilter.Chain and RowFilter.Interleave documentation.
+///
+/// The total serialized size of a RowFilter message must not
+/// exceed 20480 bytes, and RowFilters may not be nested within each other
+/// (in Chains or Interleaves) to a depth of more than 20.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RowFilter {
+    /// Which of the possible RowFilter types to apply. If none are set, this
+    /// RowFilter returns all cells in the input row.
+    #[prost(
+        oneof = "row_filter::Filter",
+        tags = "1, 2, 3, 16, 17, 18, 4, 14, 5, 6, 7, 8, 9, 15, 10, 11, 12, 13, 19"
+    )]
+    pub filter: ::core::option::Option<row_filter::Filter>,
+}
+/// Nested message and enum types in `RowFilter`.
+pub mod row_filter {
+    /// A RowFilter which sends rows through several RowFilters in sequence.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Chain {
+        /// The elements of "filters" are chained together to process the input row:
+        /// in row -> f(0) -> intermediate row -> f(1) -> ... -> f(N) -> out row
+        /// The full chain is executed atomically.
+        #[prost(message, repeated, tag = "1")]
+        pub filters: ::prost::alloc::vec::Vec<super::RowFilter>,
+    }
+    /// A RowFilter which sends each row to each of several component
+    /// RowFilters and interleaves the results.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Interleave {
+        #[prost(message, repeated, tag = "1")]
+        pub filters: ::prost::alloc::vec::Vec<super::RowFilter>,
+    }
+    /// A RowFilter which evaluates one of two possible RowFilters, depending on
+    /// whether or not a predicate RowFilter outputs any cells from the input row.
+    ///
+    /// IMPORTANT NOTE: The predicate filter does not execute atomically with the
+    /// true and false filters, which may lead to inconsistent or unexpected
+    /// results. Additionally, Condition filters have poor performance, especially
+    /// when filters are set for the false condition.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Condition {
+        /// If `predicate_filter` outputs any cells, then `true_filter` will be
+        /// evaluated on the input row. Otherwise, `false_filter` will be evaluated.
+        #[prost(message, optional, boxed, tag = "1")]
+        pub predicate_filter: ::core::option::Option<::prost::alloc::boxed::Box<super::RowFilter>>,
+        /// The filter to apply to the input row if `predicate_filter` returns any
+        /// results. If not provided, no results will be returned in the true case.
+        #[prost(message, optional, boxed, tag = "2")]
+        pub true_filter: ::core::option::Option<::prost::alloc::boxed::Box<super::RowFilter>>,
+        /// The filter to apply to the input row if `predicate_filter` does not
+        /// return any results. If not provided, no results will be returned in the
+        /// false case.
+        #[prost(message, optional, boxed, tag = "3")]
+        pub false_filter: ::core::option::Option<::prost::alloc::boxed::Box<super::RowFilter>>,
+    }
+    /// Which of the possible RowFilter types to apply. If none are set, this
+    /// RowFilter returns all cells in the input row.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Filter {
+        /// Applies several RowFilters to the data in sequence, progressively
+        /// narrowing the results.
+        #[prost(message, tag = "1")]
+        Chain(Chain),
+        /// Applies several RowFilters to the data in parallel and combines the
+        /// results.
+        #[prost(message, tag = "2")]
+        Interleave(Interleave),
+        /// Applies one of two possible RowFilters to the data based on the output of
+        /// a predicate RowFilter.
+        #[prost(message, tag = "3")]
+        Condition(::prost::alloc::boxed::Box<Condition>),
+        #[prost(bool, tag = "16")]
+        Sink(bool),
+        /// Matches all cells, regardless of input. Functionally equivalent to
+        /// leaving `filter` unset, but included for completeness.
+        #[prost(bool, tag = "17")]
+        PassAllFilter(bool),
+        /// Does not match any cells, regardless of input. Useful for temporarily
+        /// disabling just part of a filter.
+        #[prost(bool, tag = "18")]
+        BlockAllFilter(bool),
+        /// Matches only cells from rows whose keys satisfy the given RE2 regex. In
+        /// other words, passes through the entire row when the key matches, and
+        /// otherwise produces an empty row.
+        /// Note that, since row keys can contain arbitrary bytes, the `\C` escape
+        /// sequence must be used if a true wildcard is desired. The `.` character
+        /// will not match the new line character `\n`, which may be present in a
+        /// binary key.
+        #[prost(bytes, tag = "4")]
+        RowKeyRegexFilter(::prost::bytes::Bytes),
+        /// Matches all cells from a row with probability p, and matches no cells
+        /// from the row with probability 1-p.
+        #[prost(double, tag = "14")]
+        RowSampleFilter(f64),
+        /// Matches only cells from columns whose families satisfy the given RE2
+        /// regex. For technical reasons, the regex must not contain the `:`
+        /// character, even if it is not being used as a literal.
+        /// Note that, since column families cannot contain the new line character
+        /// `\n`, it is sufficient to use `.` as a full wildcard when matching
+        /// column family names.
+        #[prost(string, tag = "5")]
+        FamilyNameRegexFilter(::prost::alloc::string::String),
+        /// Matches only cells from columns whose qualifiers satisfy the given RE2
+        /// regex.
+        /// Note that, since column qualifiers can contain arbitrary bytes, the `\C`
+        /// escape sequence must be used if a true wildcard is desired. The `.`
+        /// character will not match the new line character `\n`, which may be
+        /// present in a binary qualifier.
+        #[prost(bytes, tag = "6")]
+        ColumnQualifierRegexFilter(::prost::bytes::Bytes),
+        /// Matches only cells from columns within the given range.
+        #[prost(message, tag = "7")]
+        ColumnRangeFilter(super::ColumnRange),
+        /// Matches only cells with timestamps within the given range.
+        #[prost(message, tag = "8")]
+        TimestampRangeFilter(super::TimestampRange),
+        /// Matches only cells with values that satisfy the given regular expression.
+        /// Note that, since cell values can contain arbitrary bytes, the `\C` escape
+        /// sequence must be used if a true wildcard is desired. The `.` character
+        /// will not match the new line character `\n`, which may be present in a
+        /// binary value.
+        #[prost(bytes, tag = "9")]
+        ValueRegexFilter(::prost::bytes::Bytes),
+        /// Matches only cells with values that fall within the given range.
+        #[prost(message, tag = "15")]
+        ValueRangeFilter(super::ValueRange),
+        /// Skips the first N cells of each row, matching all subsequent cells.
+        /// If duplicate cells are present, as is possible when using an Interleave,
+        /// each copy of the cell is counted separately.
+        #[prost(int32, tag = "10")]
+        CellsPerRowOffsetFilter(i32),
+        /// Matches only the first N cells of each row.
+        /// If duplicate cells are present, as is possible when using an Interleave,
+        /// each copy of the cell is counted separately.
+        #[prost(int32, tag = "11")]
+        CellsPerRowLimitFilter(i32),
+        /// Matches only the most recent N cells within each column. For example,
+        /// if N=2, this filter would match column `foo:bar` at timestamps 10 and 9,
+        /// skip all earlier cells in `foo:bar`, and then begin matching again in
+        /// column `foo:bar2`.
+        /// If duplicate cells are present, as is possible when using an Interleave,
+        /// each copy of the cell is counted separately.
+        #[prost(int32, tag = "12")]
+        CellsPerColumnLimitFilter(i32),
+        /// Replaces each cell's value with the empty string.
+        #[prost(bool, tag = "13")]
+        StripValueTransformer(bool),
+        /// Applies the given label to all cells in the output row. This allows
+        /// the client to determine which results were produced from which part of
+        /// the filter.
+        ///
+        /// Values must be at most 15 characters in length, and match the RE2
+        /// pattern `\[a-z0-9\\-\]+`
+        ///
+        /// Due to a technical limitation, it is not currently possible to apply
+        /// multiple labels to a cell. As a result, a Chain may have no more than
+        /// one sub-filter which contains a `apply_label_transformer`. It is okay for
+        /// an Interleave to contain multiple `apply_label_transformers`, as they
+        /// will be applied to separate copies of the input. This may be relaxed in
+        /// the future.
+        #[prost(string, tag = "19")]
+        ApplyLabelTransformer(::prost::alloc::string::String),
+    }
+}
+/// Specifies a particular change to be made to the contents of a row.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Mutation {
+    /// Which of the possible Mutation types to apply.
+    #[prost(oneof = "mutation::Mutation", tags = "1, 2, 3, 4")]
+    pub mutation: ::core::option::Option<mutation::Mutation>,
+}
+/// Nested message and enum types in `Mutation`.
+pub mod mutation {
+    /// A Mutation which sets the value of the specified cell.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct SetCell {
+        /// The name of the family into which new data should be written.
+        /// Must match `\[-_.a-zA-Z0-9\]+`
+        #[prost(string, tag = "1")]
+        pub family_name: ::prost::alloc::string::String,
+        /// The qualifier of the column into which new data should be written.
+        /// Can be any byte string, including the empty string.
+        #[prost(bytes = "bytes", tag = "2")]
+        pub column_qualifier: ::prost::bytes::Bytes,
+        /// The timestamp of the cell into which new data should be written.
+        /// Use -1 for current Bigtable server time.
+        /// Otherwise, the client should set this value itself, noting that the
+        /// default value is a timestamp of zero if the field is left unspecified.
+        /// Values must match the granularity of the table (e.g. micros, millis).
+        #[prost(int64, tag = "3")]
+        pub timestamp_micros: i64,
+        /// The value to be written into the specified cell.
+        #[prost(bytes = "bytes", tag = "4")]
+        pub value: ::prost::bytes::Bytes,
+    }
+    /// A Mutation which deletes cells from the specified column, optionally
+    /// restricting the deletions to a given timestamp range.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct DeleteFromColumn {
+        /// The name of the family from which cells should be deleted.
+        /// Must match `\[-_.a-zA-Z0-9\]+`
+        #[prost(string, tag = "1")]
+        pub family_name: ::prost::alloc::string::String,
+        /// The qualifier of the column from which cells should be deleted.
+        /// Can be any byte string, including the empty string.
+        #[prost(bytes = "bytes", tag = "2")]
+        pub column_qualifier: ::prost::bytes::Bytes,
+        /// The range of timestamps within which cells should be deleted.
+        #[prost(message, optional, tag = "3")]
+        pub time_range: ::core::option::Option<super::TimestampRange>,
+    }
+    /// A Mutation which deletes all cells from the specified column family.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct DeleteFromFamily {
+        /// The name of the family from which cells should be deleted.
+        /// Must match `\[-_.a-zA-Z0-9\]+`
+        #[prost(string, tag = "1")]
+        pub family_name: ::prost::alloc::string::String,
+    }
+    /// A Mutation which deletes all cells from the containing row.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct DeleteFromRow {}
+    /// Which of the possible Mutation types to apply.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Mutation {
+        /// Set a cell's value.
+        #[prost(message, tag = "1")]
+        SetCell(SetCell),
+        /// Deletes cells from a column.
+        #[prost(message, tag = "2")]
+        DeleteFromColumn(DeleteFromColumn),
+        /// Deletes cells from a column family.
+        #[prost(message, tag = "3")]
+        DeleteFromFamily(DeleteFromFamily),
+        /// Deletes cells from the entire row.
+        #[prost(message, tag = "4")]
+        DeleteFromRow(DeleteFromRow),
+    }
+}
+/// Specifies an atomic read/modify/write operation on the latest value of the
+/// specified column.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadModifyWriteRule {
+    /// The name of the family to which the read/modify/write should be applied.
+    /// Must match `\[-_.a-zA-Z0-9\]+`
+    #[prost(string, tag = "1")]
+    pub family_name: ::prost::alloc::string::String,
+    /// The qualifier of the column to which the read/modify/write should be
+    /// applied.
+    /// Can be any byte string, including the empty string.
+    #[prost(bytes = "bytes", tag = "2")]
+    pub column_qualifier: ::prost::bytes::Bytes,
+    /// The rule used to determine the column's new latest value from its current
+    /// latest value.
+    #[prost(oneof = "read_modify_write_rule::Rule", tags = "3, 4")]
+    pub rule: ::core::option::Option<read_modify_write_rule::Rule>,
+}
+/// Nested message and enum types in `ReadModifyWriteRule`.
+pub mod read_modify_write_rule {
+    /// The rule used to determine the column's new latest value from its current
+    /// latest value.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Rule {
+        /// Rule specifying that `append_value` be appended to the existing value.
+        /// If the targeted cell is unset, it will be treated as containing the
+        /// empty string.
+        #[prost(bytes, tag = "3")]
+        AppendValue(::prost::bytes::Bytes),
+        /// Rule specifying that `increment_amount` be added to the existing value.
+        /// If the targeted cell is unset, it will be treated as containing a zero.
+        /// Otherwise, the targeted cell must contain an 8-byte value (interpreted
+        /// as a 64-bit big-endian signed integer), or the entire request will fail.
+        #[prost(int64, tag = "4")]
+        IncrementAmount(i64),
+    }
+}
+//
+// Messages related to RequestStats, part of the Query Stats feature, that can
+// help understand the performance of requests.
+//
+// The layout of requests below is as follows:
+//   * RequestStats serves as the top-level container for statistics and
+//     measures related to Bigtable requests. This common object is returned as
+//     part of methods in the Data API.
+//   * RequestStats contains multiple *views* of related data, chosen by an
+//     option in the source Data API method. The view that is returned is
+//     designed to have all submessages (and their submessages, and so on)
+//     filled-in, to provide a comprehensive selection of statistics and
+//     measures related to the requested view.
+
+/// ReadIterationStats captures information about the iteration of rows or cells
+/// over the course of a read, e.g. how many results were scanned in a read
+/// operation versus the results returned.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadIterationStats {
+    /// The rows seen (scanned) as part of the request. This includes the count of
+    /// rows returned, as captured below.
+    #[prost(int64, tag = "1")]
+    pub rows_seen_count: i64,
+    /// The rows returned as part of the request.
+    #[prost(int64, tag = "2")]
+    pub rows_returned_count: i64,
+    /// The cells seen (scanned) as part of the request. This includes the count of
+    /// cells returned, as captured below.
+    #[prost(int64, tag = "3")]
+    pub cells_seen_count: i64,
+    /// The cells returned as part of the request.
+    #[prost(int64, tag = "4")]
+    pub cells_returned_count: i64,
+}
+/// RequestLatencyStats provides a measurement of the latency of the request as
+/// it interacts with different systems over its lifetime, e.g. how long the
+/// request took to execute within a frontend server.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RequestLatencyStats {
+    /// The latency measured by the frontend server handling this request, from
+    /// when the request was received, to when this value is sent back in the
+    /// response. For more context on the component that is measuring this latency,
+    /// see: <https://cloud.google.com/bigtable/docs/overview>
+    ///
+    /// Note: This value may be slightly shorter than the value reported into
+    /// aggregate latency metrics in Monitoring for this request
+    /// (<https://cloud.google.com/bigtable/docs/monitoring-instance>) as this value
+    /// needs to be sent in the response before the latency measurement including
+    /// that transmission is finalized.
+    ///
+    /// Note: This value includes the end-to-end latency of contacting nodes in
+    /// the targeted cluster, e.g. measuring from when the first byte arrives at
+    /// the frontend server, to when this value is sent back as the last value in
+    /// the response, including any latency incurred by contacting nodes, waiting
+    /// for results from nodes, and finally sending results from nodes back to the
+    /// caller.
+    #[prost(message, optional, tag = "1")]
+    pub frontend_server_latency: ::core::option::Option<::prost_types::Duration>,
+}
+/// FullReadStatsView captures all known information about a read.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FullReadStatsView {
+    /// Iteration stats describe how efficient the read is, e.g. comparing
+    /// rows seen vs. rows returned or cells seen vs cells returned can provide an
+    /// indication of read efficiency (the higher the ratio of seen to retuned the
+    /// better).
+    #[prost(message, optional, tag = "1")]
+    pub read_iteration_stats: ::core::option::Option<ReadIterationStats>,
+    /// Request latency stats describe the time taken to complete a request, from
+    /// the server side.
+    #[prost(message, optional, tag = "2")]
+    pub request_latency_stats: ::core::option::Option<RequestLatencyStats>,
+}
+/// RequestStats is the container for additional information pertaining to a
+/// single request, helpful for evaluating the performance of the sent request.
+/// Currently, there are the following supported methods:
+///   * google.bigtable.v2.ReadRows
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RequestStats {
+    /// Information pertaining to each request type received. The type is chosen
+    /// based on the requested view.
+    ///
+    /// See the messages above for additional context.
+    #[prost(oneof = "request_stats::StatsView", tags = "1")]
+    pub stats_view: ::core::option::Option<request_stats::StatsView>,
+}
+/// Nested message and enum types in `RequestStats`.
+pub mod request_stats {
+    /// Information pertaining to each request type received. The type is chosen
+    /// based on the requested view.
+    ///
+    /// See the messages above for additional context.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum StatsView {
+        /// Available with the ReadRowsRequest.RequestStatsView.REQUEST_STATS_FULL
+        /// view, see package google.bigtable.v2.
+        #[prost(message, tag = "1")]
+        FullReadStatsView(super::FullReadStatsView),
+    }
+}
+/// Request message for Bigtable.ReadRows.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadRowsRequest {
+    /// Required. The unique name of the table from which to read.
+    /// Values are of the form
+    /// `projects/<project>/instances/<instance>/tables/<table>`.
+    #[prost(string, tag = "1")]
+    pub table_name: ::prost::alloc::string::String,
+    /// This value specifies routing for replication. This API only accepts the
+    /// empty value of app_profile_id.
+    #[prost(string, tag = "5")]
+    pub app_profile_id: ::prost::alloc::string::String,
+    /// The row keys and/or ranges to read sequentially. If not specified, reads
+    /// from all rows.
+    #[prost(message, optional, tag = "2")]
+    pub rows: ::core::option::Option<RowSet>,
+    /// The filter to apply to the contents of the specified row(s). If unset,
+    /// reads the entirety of each row.
+    #[prost(message, optional, tag = "3")]
+    pub filter: ::core::option::Option<RowFilter>,
+    /// The read will stop after committing to N rows' worth of results. The
+    /// default (zero) is to return all results.
+    #[prost(int64, tag = "4")]
+    pub rows_limit: i64,
+    /// The view into RequestStats, as described above.
+    #[prost(enumeration = "read_rows_request::RequestStatsView", tag = "6")]
+    pub request_stats_view: i32,
+}
+/// Nested message and enum types in `ReadRowsRequest`.
+pub mod read_rows_request {
+    ///
+    /// The desired view into RequestStats that should be returned in the response.
+    ///
+    /// See also: RequestStats message.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum RequestStatsView {
+        /// The default / unset value. The API will default to the NONE option below.
+        Unspecified = 0,
+        /// Do not include any RequestStats in the response. This will leave the
+        /// RequestStats embedded message unset in the response.
+        RequestStatsNone = 1,
+        /// Include the full set of available RequestStats in the response,
+        /// applicable to this read.
+        RequestStatsFull = 2,
+    }
+}
+/// Response message for Bigtable.ReadRows.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadRowsResponse {
+    /// A collection of a row's contents as part of the read request.
+    #[prost(message, repeated, tag = "1")]
+    pub chunks: ::prost::alloc::vec::Vec<read_rows_response::CellChunk>,
+    /// Optionally the server might return the row key of the last row it
+    /// has scanned.  The client can use this to construct a more
+    /// efficient retry request if needed: any row keys or portions of
+    /// ranges less than this row key can be dropped from the request.
+    /// This is primarily useful for cases where the server has read a
+    /// lot of data that was filtered out since the last committed row
+    /// key, allowing the client to skip that work on a retry.
+    #[prost(bytes = "bytes", tag = "2")]
+    pub last_scanned_row_key: ::prost::bytes::Bytes,
+    ///
+    /// If requested, provide enhanced query performance statistics. The semantics
+    /// dictate:
+    ///   * request_stats is empty on every (streamed) response, except
+    ///   * request_stats has non-empty information after all chunks have been
+    ///     streamed, where the ReadRowsResponse message only contains
+    ///     request_stats.
+    ///       * For example, if a read request would have returned an empty
+    ///         response instead a single ReadRowsResponse is streamed with empty
+    ///         chunks and request_stats filled.
+    ///
+    /// Visually, response messages will stream as follows:
+    ///    ... -> {chunks: \[...\]} -> {chunks: [], request_stats: {...}}
+    ///   \______________________/  \________________________________/
+    ///       Primary response         Trailer of RequestStats info
+    ///
+    /// Or if the read did not return any values:
+    ///   {chunks: [], request_stats: {...}}
+    ///   \________________________________/
+    ///      Trailer of RequestStats info
+    #[prost(message, optional, tag = "3")]
+    pub request_stats: ::core::option::Option<RequestStats>,
+}
+/// Nested message and enum types in `ReadRowsResponse`.
+pub mod read_rows_response {
+    /// Specifies a piece of a row's contents returned as part of the read
+    /// response stream.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct CellChunk {
+        /// The row key for this chunk of data.  If the row key is empty,
+        /// this CellChunk is a continuation of the same row as the previous
+        /// CellChunk in the response stream, even if that CellChunk was in a
+        /// previous ReadRowsResponse message.
+        #[prost(bytes = "bytes", tag = "1")]
+        pub row_key: ::prost::bytes::Bytes,
+        /// The column family name for this chunk of data.  If this message
+        /// is not present this CellChunk is a continuation of the same column
+        /// family as the previous CellChunk.  The empty string can occur as a
+        /// column family name in a response so clients must check
+        /// explicitly for the presence of this message, not just for
+        /// `family_name.value` being non-empty.
+        #[prost(message, optional, tag = "2")]
+        pub family_name: ::core::option::Option<::prost::alloc::string::String>,
+        /// The column qualifier for this chunk of data.  If this message
+        /// is not present, this CellChunk is a continuation of the same column
+        /// as the previous CellChunk.  Column qualifiers may be empty so
+        /// clients must check for the presence of this message, not just
+        /// for `qualifier.value` being non-empty.
+        #[prost(message, optional, tag = "3")]
+        pub qualifier: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+        /// The cell's stored timestamp, which also uniquely identifies it
+        /// within its column.  Values are always expressed in
+        /// microseconds, but individual tables may set a coarser
+        /// granularity to further restrict the allowed values. For
+        /// example, a table which specifies millisecond granularity will
+        /// only allow values of `timestamp_micros` which are multiples of
+        /// 1000.  Timestamps are only set in the first CellChunk per cell
+        /// (for cells split into multiple chunks).
+        #[prost(int64, tag = "4")]
+        pub timestamp_micros: i64,
+        /// Labels applied to the cell by a
+        /// \[RowFilter][google.bigtable.v2.RowFilter\].  Labels are only set
+        /// on the first CellChunk per cell.
+        #[prost(string, repeated, tag = "5")]
+        pub labels: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+        /// The value stored in the cell.  Cell values can be split across
+        /// multiple CellChunks.  In that case only the value field will be
+        /// set in CellChunks after the first: the timestamp and labels
+        /// will only be present in the first CellChunk, even if the first
+        /// CellChunk came in a previous ReadRowsResponse.
+        #[prost(bytes = "bytes", tag = "6")]
+        pub value: ::prost::bytes::Bytes,
+        /// If this CellChunk is part of a chunked cell value and this is
+        /// not the final chunk of that cell, value_size will be set to the
+        /// total length of the cell value.  The client can use this size
+        /// to pre-allocate memory to hold the full cell value.
+        #[prost(int32, tag = "7")]
+        pub value_size: i32,
+        /// Signals to the client concerning previous CellChunks received.
+        #[prost(oneof = "cell_chunk::RowStatus", tags = "8, 9")]
+        pub row_status: ::core::option::Option<cell_chunk::RowStatus>,
+    }
+    /// Nested message and enum types in `CellChunk`.
+    pub mod cell_chunk {
+        /// Signals to the client concerning previous CellChunks received.
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub enum RowStatus {
+            /// Indicates that the client should drop all previous chunks for
+            /// `row_key`, as it will be re-read from the beginning.
+            #[prost(bool, tag = "8")]
+            ResetRow(bool),
+            /// Indicates that the client can safely process all previous chunks for
+            /// `row_key`, as its data has been fully read.
+            #[prost(bool, tag = "9")]
+            CommitRow(bool),
+        }
+    }
+}
+/// Request message for Bigtable.SampleRowKeys.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SampleRowKeysRequest {
+    /// Required. The unique name of the table from which to sample row keys.
+    /// Values are of the form
+    /// `projects/<project>/instances/<instance>/tables/<table>`.
+    #[prost(string, tag = "1")]
+    pub table_name: ::prost::alloc::string::String,
+    /// This value specifies routing for replication. If not specified, the
+    /// "default" application profile will be used.
+    #[prost(string, tag = "2")]
+    pub app_profile_id: ::prost::alloc::string::String,
+}
+/// Response message for Bigtable.SampleRowKeys.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SampleRowKeysResponse {
+    /// Sorted streamed sequence of sample row keys in the table. The table might
+    /// have contents before the first row key in the list and after the last one,
+    /// but a key containing the empty string indicates "end of table" and will be
+    /// the last response given, if present.
+    /// Note that row keys in this list may not have ever been written to or read
+    /// from, and users should therefore not make any assumptions about the row key
+    /// structure that are specific to their use case.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub row_key: ::prost::bytes::Bytes,
+    /// Approximate total storage space used by all rows in the table which precede
+    /// `row_key`. Buffering the contents of all rows between two subsequent
+    /// samples would require space roughly equal to the difference in their
+    /// `offset_bytes` fields.
+    #[prost(int64, tag = "2")]
+    pub offset_bytes: i64,
+}
+/// Request message for Bigtable.MutateRow.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MutateRowRequest {
+    /// Required. The unique name of the table to which the mutation should be applied.
+    /// Values are of the form
+    /// `projects/<project>/instances/<instance>/tables/<table>`.
+    #[prost(string, tag = "1")]
+    pub table_name: ::prost::alloc::string::String,
+    /// This value specifies routing for replication. If not specified, the
+    /// "default" application profile will be used.
+    #[prost(string, tag = "4")]
+    pub app_profile_id: ::prost::alloc::string::String,
+    /// Required. The key of the row to which the mutation should be applied.
+    #[prost(bytes = "bytes", tag = "2")]
+    pub row_key: ::prost::bytes::Bytes,
+    /// Required. Changes to be atomically applied to the specified row. Entries are applied
+    /// in order, meaning that earlier mutations can be masked by later ones.
+    /// Must contain at least one entry and at most 100000.
+    #[prost(message, repeated, tag = "3")]
+    pub mutations: ::prost::alloc::vec::Vec<Mutation>,
+}
+/// Response message for Bigtable.MutateRow.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MutateRowResponse {}
+/// Request message for BigtableService.MutateRows.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MutateRowsRequest {
+    /// Required. The unique name of the table to which the mutations should be applied.
+    #[prost(string, tag = "1")]
+    pub table_name: ::prost::alloc::string::String,
+    /// This value specifies routing for replication. If not specified, the
+    /// "default" application profile will be used.
+    #[prost(string, tag = "3")]
+    pub app_profile_id: ::prost::alloc::string::String,
+    /// Required. The row keys and corresponding mutations to be applied in bulk.
+    /// Each entry is applied as an atomic mutation, but the entries may be
+    /// applied in arbitrary order (even between entries for the same row).
+    /// At least one entry must be specified, and in total the entries can
+    /// contain at most 100000 mutations.
+    #[prost(message, repeated, tag = "2")]
+    pub entries: ::prost::alloc::vec::Vec<mutate_rows_request::Entry>,
+}
+/// Nested message and enum types in `MutateRowsRequest`.
+pub mod mutate_rows_request {
+    /// A mutation for a given row.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Entry {
+        /// The key of the row to which the `mutations` should be applied.
+        #[prost(bytes = "bytes", tag = "1")]
+        pub row_key: ::prost::bytes::Bytes,
+        /// Required. Changes to be atomically applied to the specified row. Mutations are
+        /// applied in order, meaning that earlier mutations can be masked by
+        /// later ones.
+        /// You must specify at least one mutation.
+        #[prost(message, repeated, tag = "2")]
+        pub mutations: ::prost::alloc::vec::Vec<super::Mutation>,
+    }
+}
+/// Response message for BigtableService.MutateRows.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MutateRowsResponse {
+    /// One or more results for Entries from the batch request.
+    #[prost(message, repeated, tag = "1")]
+    pub entries: ::prost::alloc::vec::Vec<mutate_rows_response::Entry>,
+}
+/// Nested message and enum types in `MutateRowsResponse`.
+pub mod mutate_rows_response {
+    /// The result of applying a passed mutation in the original request.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Entry {
+        /// The index into the original request's `entries` list of the Entry
+        /// for which a result is being reported.
+        #[prost(int64, tag = "1")]
+        pub index: i64,
+        /// The result of the request Entry identified by `index`.
+        /// Depending on how requests are batched during execution, it is possible
+        /// for one Entry to fail due to an error with another Entry. In the event
+        /// that this occurs, the same error will be reported for both entries.
+        #[prost(message, optional, tag = "2")]
+        pub status: ::core::option::Option<super::super::super::rpc::Status>,
+    }
+}
+/// Request message for Bigtable.CheckAndMutateRow.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CheckAndMutateRowRequest {
+    /// Required. The unique name of the table to which the conditional mutation should be
+    /// applied.
+    /// Values are of the form
+    /// `projects/<project>/instances/<instance>/tables/<table>`.
+    #[prost(string, tag = "1")]
+    pub table_name: ::prost::alloc::string::String,
+    /// This value specifies routing for replication. If not specified, the
+    /// "default" application profile will be used.
+    #[prost(string, tag = "7")]
+    pub app_profile_id: ::prost::alloc::string::String,
+    /// Required. The key of the row to which the conditional mutation should be applied.
+    #[prost(bytes = "bytes", tag = "2")]
+    pub row_key: ::prost::bytes::Bytes,
+    /// The filter to be applied to the contents of the specified row. Depending
+    /// on whether or not any results are yielded, either `true_mutations` or
+    /// `false_mutations` will be executed. If unset, checks that the row contains
+    /// any values at all.
+    #[prost(message, optional, tag = "6")]
+    pub predicate_filter: ::core::option::Option<RowFilter>,
+    /// Changes to be atomically applied to the specified row if `predicate_filter`
+    /// yields at least one cell when applied to `row_key`. Entries are applied in
+    /// order, meaning that earlier mutations can be masked by later ones.
+    /// Must contain at least one entry if `false_mutations` is empty, and at most
+    /// 100000.
+    #[prost(message, repeated, tag = "4")]
+    pub true_mutations: ::prost::alloc::vec::Vec<Mutation>,
+    /// Changes to be atomically applied to the specified row if `predicate_filter`
+    /// does not yield any cells when applied to `row_key`. Entries are applied in
+    /// order, meaning that earlier mutations can be masked by later ones.
+    /// Must contain at least one entry if `true_mutations` is empty, and at most
+    /// 100000.
+    #[prost(message, repeated, tag = "5")]
+    pub false_mutations: ::prost::alloc::vec::Vec<Mutation>,
+}
+/// Response message for Bigtable.CheckAndMutateRow.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CheckAndMutateRowResponse {
+    /// Whether or not the request's `predicate_filter` yielded any results for
+    /// the specified row.
+    #[prost(bool, tag = "1")]
+    pub predicate_matched: bool,
+}
+/// Request message for client connection keep-alive and warming.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PingAndWarmRequest {
+    /// Required. The unique name of the instance to check permissions for as well as
+    /// respond. Values are of the form `projects/<project>/instances/<instance>`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// This value specifies routing for replication. If not specified, the
+    /// "default" application profile will be used.
+    #[prost(string, tag = "2")]
+    pub app_profile_id: ::prost::alloc::string::String,
+}
+/// Response message for Bigtable.PingAndWarm connection keepalive and warming.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PingAndWarmResponse {}
+/// Request message for Bigtable.ReadModifyWriteRow.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadModifyWriteRowRequest {
+    /// Required. The unique name of the table to which the read/modify/write rules should be
+    /// applied.
+    /// Values are of the form
+    /// `projects/<project>/instances/<instance>/tables/<table>`.
+    #[prost(string, tag = "1")]
+    pub table_name: ::prost::alloc::string::String,
+    /// This value specifies routing for replication. If not specified, the
+    /// "default" application profile will be used.
+    #[prost(string, tag = "4")]
+    pub app_profile_id: ::prost::alloc::string::String,
+    /// Required. The key of the row to which the read/modify/write rules should be applied.
+    #[prost(bytes = "bytes", tag = "2")]
+    pub row_key: ::prost::bytes::Bytes,
+    /// Required. Rules specifying how the specified row's contents are to be transformed
+    /// into writes. Entries are applied in order, meaning that earlier rules will
+    /// affect the results of later ones.
+    #[prost(message, repeated, tag = "3")]
+    pub rules: ::prost::alloc::vec::Vec<ReadModifyWriteRule>,
+}
+/// Response message for Bigtable.ReadModifyWriteRow.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadModifyWriteRowResponse {
+    /// A Row containing the new contents of all cells modified by the request.
+    #[prost(message, optional, tag = "1")]
+    pub row: ::core::option::Option<Row>,
+}
+#[doc = r" Generated client implementations."]
+pub mod bigtable_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[doc = " Service for reading from and writing to existing Bigtable tables."]
+    #[derive(Debug, Clone)]
+    pub struct BigtableClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl BigtableClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> BigtableClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> BigtableClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            BigtableClient::new(InterceptedService::new(inner, interceptor))
+        }
+        #[doc = r" Compress requests with `gzip`."]
+        #[doc = r""]
+        #[doc = r" This requires the server to support it otherwise it might respond with an"]
+        #[doc = r" error."]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        #[doc = r" Enable decompressing responses with `gzip`."]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        #[doc = " Streams back the contents of all requested rows in key order, optionally"]
+        #[doc = " applying the same Reader filter to each. Depending on their size,"]
+        #[doc = " rows and cells may be broken up across multiple responses, but"]
+        #[doc = " atomicity of each row will still be preserved. See the"]
+        #[doc = " ReadRowsResponse documentation for details."]
+        pub async fn read_rows(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ReadRowsRequest>,
+        ) -> Result<tonic::Response<tonic::codec::Streaming<super::ReadRowsResponse>>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/google.bigtable.v2.Bigtable/ReadRows");
+            self.inner
+                .server_streaming(request.into_request(), path, codec)
+                .await
+        }
+        #[doc = " Returns a sample of row keys in the table. The returned row keys will"]
+        #[doc = " delimit contiguous sections of the table of approximately equal size,"]
+        #[doc = " which can be used to break up the data for distributed tasks like"]
+        #[doc = " mapreduces."]
+        pub async fn sample_row_keys(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SampleRowKeysRequest>,
+        ) -> Result<
+            tonic::Response<tonic::codec::Streaming<super::SampleRowKeysResponse>>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/google.bigtable.v2.Bigtable/SampleRowKeys");
+            self.inner
+                .server_streaming(request.into_request(), path, codec)
+                .await
+        }
+        #[doc = " Mutates a row atomically. Cells already present in the row are left"]
+        #[doc = " unchanged unless explicitly changed by `mutation`."]
+        pub async fn mutate_row(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MutateRowRequest>,
+        ) -> Result<tonic::Response<super::MutateRowResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/google.bigtable.v2.Bigtable/MutateRow");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Mutates multiple rows in a batch. Each individual row is mutated"]
+        #[doc = " atomically as in MutateRow, but the entire batch is not executed"]
+        #[doc = " atomically."]
+        pub async fn mutate_rows(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MutateRowsRequest>,
+        ) -> Result<
+            tonic::Response<tonic::codec::Streaming<super::MutateRowsResponse>>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/google.bigtable.v2.Bigtable/MutateRows");
+            self.inner
+                .server_streaming(request.into_request(), path, codec)
+                .await
+        }
+        #[doc = " Mutates a row atomically based on the output of a predicate Reader filter."]
+        pub async fn check_and_mutate_row(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CheckAndMutateRowRequest>,
+        ) -> Result<tonic::Response<super::CheckAndMutateRowResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.v2.Bigtable/CheckAndMutateRow",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Warm up associated instance metadata for this connection."]
+        #[doc = " This call is not required but may be useful for connection keep-alive."]
+        pub async fn ping_and_warm(
+            &mut self,
+            request: impl tonic::IntoRequest<super::PingAndWarmRequest>,
+        ) -> Result<tonic::Response<super::PingAndWarmResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/google.bigtable.v2.Bigtable/PingAndWarm");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Modifies a row atomically on the server. The method reads the latest"]
+        #[doc = " existing timestamp and value from the specified columns and writes a new"]
+        #[doc = " entry based on pre-defined read/modify/write rules. The new value for the"]
+        #[doc = " timestamp is the greater of the existing timestamp or the current server"]
+        #[doc = " time. The method returns the new contents of all modified cells."]
+        pub async fn read_modify_write_row(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ReadModifyWriteRowRequest>,
+        ) -> Result<tonic::Response<super::ReadModifyWriteRowResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.bigtable.v2.Bigtable/ReadModifyWriteRow",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}

--- a/src/generated/google.iam.v1.rs
+++ b/src/generated/google.iam.v1.rs
@@ -1,0 +1,476 @@
+/// Encapsulates settings provided to GetIamPolicy.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPolicyOptions {
+    /// Optional. The maximum policy version that will be used to format the
+    /// policy.
+    ///
+    /// Valid values are 0, 1, and 3. Requests specifying an invalid value will be
+    /// rejected.
+    ///
+    /// Requests for policies with any conditional role bindings must specify
+    /// version 3. Policies with no conditional role bindings may specify any valid
+    /// value or leave the field unset.
+    ///
+    /// The policy in the response might use the policy version that you specified,
+    /// or it might use a lower policy version. For example, if you specify version
+    /// 3, but the policy has no conditional role bindings, the response uses
+    /// version 1.
+    ///
+    /// To learn which resources support conditions in their IAM policies, see the
+    /// [IAM
+    /// documentation](<https://cloud.google.com/iam/help/conditions/resource-policies>).
+    #[prost(int32, tag = "1")]
+    pub requested_policy_version: i32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Policy {
+    /// Specifies the format of the policy.
+    ///
+    /// Valid values are `0`, `1`, and `3`. Requests that specify an invalid value
+    /// are rejected.
+    ///
+    /// Any operation that affects conditional role bindings must specify version
+    /// `3`. This requirement applies to the following operations:
+    ///
+    /// * Getting a policy that includes a conditional role binding
+    /// * Adding a conditional role binding to a policy
+    /// * Changing a conditional role binding in a policy
+    /// * Removing any role binding, with or without a condition, from a policy
+    ///   that includes conditions
+    ///
+    /// **Important:** If you use IAM Conditions, you must include the `etag` field
+    /// whenever you call `setIamPolicy`. If you omit this field, then IAM allows
+    /// you to overwrite a version `3` policy with a version `1` policy, and all of
+    /// the conditions in the version `3` policy are lost.
+    ///
+    /// If a policy does not include any conditions, operations on that policy may
+    /// specify any valid version or leave the field unset.
+    ///
+    /// To learn which resources support conditions in their IAM policies, see the
+    /// [IAM documentation](<https://cloud.google.com/iam/help/conditions/resource-policies>).
+    #[prost(int32, tag = "1")]
+    pub version: i32,
+    /// Associates a list of `members`, or principals, with a `role`. Optionally,
+    /// may specify a `condition` that determines how and when the `bindings` are
+    /// applied. Each of the `bindings` must contain at least one principal.
+    ///
+    /// The `bindings` in a `Policy` can refer to up to 1,500 principals; up to 250
+    /// of these principals can be Google groups. Each occurrence of a principal
+    /// counts towards these limits. For example, if the `bindings` grant 50
+    /// different roles to `user:alice@example.com`, and not to any other
+    /// principal, then you can add another 1,450 principals to the `bindings` in
+    /// the `Policy`.
+    #[prost(message, repeated, tag = "4")]
+    pub bindings: ::prost::alloc::vec::Vec<Binding>,
+    /// Specifies cloud audit logging configuration for this policy.
+    #[prost(message, repeated, tag = "6")]
+    pub audit_configs: ::prost::alloc::vec::Vec<AuditConfig>,
+    /// `etag` is used for optimistic concurrency control as a way to help
+    /// prevent simultaneous updates of a policy from overwriting each other.
+    /// It is strongly suggested that systems make use of the `etag` in the
+    /// read-modify-write cycle to perform policy updates in order to avoid race
+    /// conditions: An `etag` is returned in the response to `getIamPolicy`, and
+    /// systems are expected to put that etag in the request to `setIamPolicy` to
+    /// ensure that their change will be applied to the same version of the policy.
+    ///
+    /// **Important:** If you use IAM Conditions, you must include the `etag` field
+    /// whenever you call `setIamPolicy`. If you omit this field, then IAM allows
+    /// you to overwrite a version `3` policy with a version `1` policy, and all of
+    /// the conditions in the version `3` policy are lost.
+    #[prost(bytes = "bytes", tag = "3")]
+    pub etag: ::prost::bytes::Bytes,
+}
+/// Associates `members`, or principals, with a `role`.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Binding {
+    /// Role that is assigned to the list of `members`, or principals.
+    /// For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
+    #[prost(string, tag = "1")]
+    pub role: ::prost::alloc::string::String,
+    /// Specifies the principals requesting access for a Cloud Platform resource.
+    /// `members` can have the following values:
+    ///
+    /// * `allUsers`: A special identifier that represents anyone who is
+    ///    on the internet; with or without a Google account.
+    ///
+    /// * `allAuthenticatedUsers`: A special identifier that represents anyone
+    ///    who is authenticated with a Google account or a service account.
+    ///
+    /// * `user:{emailid}`: An email address that represents a specific Google
+    ///    account. For example, `alice@example.com` .
+    ///
+    ///
+    /// * `serviceAccount:{emailid}`: An email address that represents a service
+    ///    account. For example, `my-other-app@appspot.gserviceaccount.com`.
+    ///
+    /// * `group:{emailid}`: An email address that represents a Google group.
+    ///    For example, `admins@example.com`.
+    ///
+    /// * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique
+    ///    identifier) representing a user that has been recently deleted. For
+    ///    example, `alice@example.com?uid=123456789012345678901`. If the user is
+    ///    recovered, this value reverts to `user:{emailid}` and the recovered user
+    ///    retains the role in the binding.
+    ///
+    /// * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus
+    ///    unique identifier) representing a service account that has been recently
+    ///    deleted. For example,
+    ///    `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`.
+    ///    If the service account is undeleted, this value reverts to
+    ///    `serviceAccount:{emailid}` and the undeleted service account retains the
+    ///    role in the binding.
+    ///
+    /// * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique
+    ///    identifier) representing a Google group that has been recently
+    ///    deleted. For example, `admins@example.com?uid=123456789012345678901`. If
+    ///    the group is recovered, this value reverts to `group:{emailid}` and the
+    ///    recovered group retains the role in the binding.
+    ///
+    ///
+    /// * `domain:{domain}`: The G Suite domain (primary) that represents all the
+    ///    users of that domain. For example, `google.com` or `example.com`.
+    ///
+    ///
+    #[prost(string, repeated, tag = "2")]
+    pub members: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// The condition that is associated with this binding.
+    ///
+    /// If the condition evaluates to `true`, then this binding applies to the
+    /// current request.
+    ///
+    /// If the condition evaluates to `false`, then this binding does not apply to
+    /// the current request. However, a different role binding might grant the same
+    /// role to one or more of the principals in this binding.
+    ///
+    /// To learn which resources support conditions in their IAM policies, see the
+    /// [IAM
+    /// documentation](<https://cloud.google.com/iam/help/conditions/resource-policies>).
+    #[prost(message, optional, tag = "3")]
+    pub condition: ::core::option::Option<super::super::r#type::Expr>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuditConfig {
+    /// Specifies a service that will be enabled for audit logging.
+    /// For example, `storage.googleapis.com`, `cloudsql.googleapis.com`.
+    /// `allServices` is a special value that covers all services.
+    #[prost(string, tag = "1")]
+    pub service: ::prost::alloc::string::String,
+    /// The configuration for logging of each type of permission.
+    #[prost(message, repeated, tag = "3")]
+    pub audit_log_configs: ::prost::alloc::vec::Vec<AuditLogConfig>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuditLogConfig {
+    /// The log type that this config enables.
+    #[prost(enumeration = "audit_log_config::LogType", tag = "1")]
+    pub log_type: i32,
+    /// Specifies the identities that do not cause logging for this type of
+    /// permission.
+    /// Follows the same format of \[Binding.members][google.iam.v1.Binding.members\].
+    #[prost(string, repeated, tag = "2")]
+    pub exempted_members: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Nested message and enum types in `AuditLogConfig`.
+pub mod audit_log_config {
+    /// The list of valid permission types for which logging can be configured.
+    /// Admin writes are always logged, and are not configurable.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum LogType {
+        /// Default case. Should never be this.
+        Unspecified = 0,
+        /// Admin reads. Example: CloudIAM getIamPolicy
+        AdminRead = 1,
+        /// Data writes. Example: CloudSQL Users create
+        DataWrite = 2,
+        /// Data reads. Example: CloudSQL Users list
+        DataRead = 3,
+    }
+}
+/// The difference delta between two policies.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PolicyDelta {
+    /// The delta for Bindings between two policies.
+    #[prost(message, repeated, tag = "1")]
+    pub binding_deltas: ::prost::alloc::vec::Vec<BindingDelta>,
+    /// The delta for AuditConfigs between two policies.
+    #[prost(message, repeated, tag = "2")]
+    pub audit_config_deltas: ::prost::alloc::vec::Vec<AuditConfigDelta>,
+}
+/// One delta entry for Binding. Each individual change (only one member in each
+/// entry) to a binding will be a separate entry.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BindingDelta {
+    /// The action that was performed on a Binding.
+    /// Required
+    #[prost(enumeration = "binding_delta::Action", tag = "1")]
+    pub action: i32,
+    /// Role that is assigned to `members`.
+    /// For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
+    /// Required
+    #[prost(string, tag = "2")]
+    pub role: ::prost::alloc::string::String,
+    /// A single identity requesting access for a Cloud Platform resource.
+    /// Follows the same format of Binding.members.
+    /// Required
+    #[prost(string, tag = "3")]
+    pub member: ::prost::alloc::string::String,
+    /// The condition that is associated with this binding.
+    #[prost(message, optional, tag = "4")]
+    pub condition: ::core::option::Option<super::super::r#type::Expr>,
+}
+/// Nested message and enum types in `BindingDelta`.
+pub mod binding_delta {
+    /// The type of action performed on a Binding in a policy.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Action {
+        /// Unspecified.
+        Unspecified = 0,
+        /// Addition of a Binding.
+        Add = 1,
+        /// Removal of a Binding.
+        Remove = 2,
+    }
+}
+/// One delta entry for AuditConfig. Each individual change (only one
+/// exempted_member in each entry) to a AuditConfig will be a separate entry.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuditConfigDelta {
+    /// The action that was performed on an audit configuration in a policy.
+    /// Required
+    #[prost(enumeration = "audit_config_delta::Action", tag = "1")]
+    pub action: i32,
+    /// Specifies a service that was configured for Cloud Audit Logging.
+    /// For example, `storage.googleapis.com`, `cloudsql.googleapis.com`.
+    /// `allServices` is a special value that covers all services.
+    /// Required
+    #[prost(string, tag = "2")]
+    pub service: ::prost::alloc::string::String,
+    /// A single identity that is exempted from "data access" audit
+    /// logging for the `service` specified above.
+    /// Follows the same format of Binding.members.
+    #[prost(string, tag = "3")]
+    pub exempted_member: ::prost::alloc::string::String,
+    /// Specifies the log_type that was be enabled. ADMIN_ACTIVITY is always
+    /// enabled, and cannot be configured.
+    /// Required
+    #[prost(string, tag = "4")]
+    pub log_type: ::prost::alloc::string::String,
+}
+/// Nested message and enum types in `AuditConfigDelta`.
+pub mod audit_config_delta {
+    /// The type of action performed on an audit configuration in a policy.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Action {
+        /// Unspecified.
+        Unspecified = 0,
+        /// Addition of an audit configuration.
+        Add = 1,
+        /// Removal of an audit configuration.
+        Remove = 2,
+    }
+}
+/// Request message for `SetIamPolicy` method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetIamPolicyRequest {
+    /// REQUIRED: The resource for which the policy is being specified.
+    /// See the operation documentation for the appropriate value for this field.
+    #[prost(string, tag = "1")]
+    pub resource: ::prost::alloc::string::String,
+    /// REQUIRED: The complete policy to be applied to the `resource`. The size of
+    /// the policy is limited to a few 10s of KB. An empty policy is a
+    /// valid policy but certain Cloud Platform services (such as Projects)
+    /// might reject them.
+    #[prost(message, optional, tag = "2")]
+    pub policy: ::core::option::Option<Policy>,
+    /// OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only
+    /// the fields in the mask will be modified. If no mask is provided, the
+    /// following default mask is used:
+    ///
+    /// `paths: "bindings, etag"`
+    #[prost(message, optional, tag = "3")]
+    pub update_mask: ::core::option::Option<::prost_types::FieldMask>,
+}
+/// Request message for `GetIamPolicy` method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetIamPolicyRequest {
+    /// REQUIRED: The resource for which the policy is being requested.
+    /// See the operation documentation for the appropriate value for this field.
+    #[prost(string, tag = "1")]
+    pub resource: ::prost::alloc::string::String,
+    /// OPTIONAL: A `GetPolicyOptions` object for specifying options to
+    /// `GetIamPolicy`.
+    #[prost(message, optional, tag = "2")]
+    pub options: ::core::option::Option<GetPolicyOptions>,
+}
+/// Request message for `TestIamPermissions` method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TestIamPermissionsRequest {
+    /// REQUIRED: The resource for which the policy detail is being requested.
+    /// See the operation documentation for the appropriate value for this field.
+    #[prost(string, tag = "1")]
+    pub resource: ::prost::alloc::string::String,
+    /// The set of permissions to check for the `resource`. Permissions with
+    /// wildcards (such as '*' or 'storage.*') are not allowed. For more
+    /// information see
+    /// [IAM Overview](<https://cloud.google.com/iam/docs/overview#permissions>).
+    #[prost(string, repeated, tag = "2")]
+    pub permissions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Response message for `TestIamPermissions` method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TestIamPermissionsResponse {
+    /// A subset of `TestPermissionsRequest.permissions` that the caller is
+    /// allowed.
+    #[prost(string, repeated, tag = "1")]
+    pub permissions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[doc = r" Generated client implementations."]
+pub mod iam_policy_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[doc = " API Overview"]
+    #[doc = ""]
+    #[doc = ""]
+    #[doc = " Manages Identity and Access Management (IAM) policies."]
+    #[doc = ""]
+    #[doc = " Any implementation of an API that offers access control features"]
+    #[doc = " implements the google.iam.v1.IAMPolicy interface."]
+    #[doc = ""]
+    #[doc = " ## Data model"]
+    #[doc = ""]
+    #[doc = " Access control is applied when a principal (user or service account), takes"]
+    #[doc = " some action on a resource exposed by a service. Resources, identified by"]
+    #[doc = " URI-like names, are the unit of access control specification. Service"]
+    #[doc = " implementations can choose the granularity of access control and the"]
+    #[doc = " supported permissions for their resources."]
+    #[doc = " For example one database service may allow access control to be"]
+    #[doc = " specified only at the Table level, whereas another might allow access control"]
+    #[doc = " to also be specified at the Column level."]
+    #[doc = ""]
+    #[doc = " ## Policy Structure"]
+    #[doc = ""]
+    #[doc = " See google.iam.v1.Policy"]
+    #[doc = ""]
+    #[doc = " This is intentionally not a CRUD style API because access control policies"]
+    #[doc = " are created and deleted implicitly with the resources to which they are"]
+    #[doc = " attached."]
+    #[derive(Debug, Clone)]
+    pub struct IamPolicyClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl IamPolicyClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> IamPolicyClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> IamPolicyClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            IamPolicyClient::new(InterceptedService::new(inner, interceptor))
+        }
+        #[doc = r" Compress requests with `gzip`."]
+        #[doc = r""]
+        #[doc = r" This requires the server to support it otherwise it might respond with an"]
+        #[doc = r" error."]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        #[doc = r" Enable decompressing responses with `gzip`."]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        #[doc = " Sets the access control policy on the specified resource. Replaces any"]
+        #[doc = " existing policy."]
+        #[doc = ""]
+        #[doc = " Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors."]
+        pub async fn set_iam_policy(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SetIamPolicyRequest>,
+        ) -> Result<tonic::Response<super::Policy>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/google.iam.v1.IAMPolicy/SetIamPolicy");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Gets the access control policy for a resource."]
+        #[doc = " Returns an empty policy if the resource exists and does not have a policy"]
+        #[doc = " set."]
+        pub async fn get_iam_policy(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetIamPolicyRequest>,
+        ) -> Result<tonic::Response<super::Policy>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/google.iam.v1.IAMPolicy/GetIamPolicy");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Returns permissions that a caller has on the specified resource."]
+        #[doc = " If the resource does not exist, this will return an empty set of"]
+        #[doc = " permissions, not a `NOT_FOUND` error."]
+        #[doc = ""]
+        #[doc = " Note: This operation is designed to be used for building permission-aware"]
+        #[doc = " UIs and command-line tools, not for authorization checking. This operation"]
+        #[doc = " may \"fail open\" without warning."]
+        pub async fn test_iam_permissions(
+            &mut self,
+            request: impl tonic::IntoRequest<super::TestIamPermissionsRequest>,
+        ) -> Result<tonic::Response<super::TestIamPermissionsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/google.iam.v1.IAMPolicy/TestIamPermissions");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}

--- a/src/generated/google.longrunning.rs
+++ b/src/generated/google.longrunning.rs
@@ -1,0 +1,326 @@
+/// This resource represents a long-running operation that is the result of a
+/// network API call.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    /// The server-assigned name, which is only unique within the same service that
+    /// originally returns it. If you use the default HTTP mapping, the
+    /// `name` should be a resource name ending with `operations/{unique_id}`.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Service-specific metadata associated with the operation.  It typically
+    /// contains progress information and common metadata such as create time.
+    /// Some services might not provide such metadata.  Any method that returns a
+    /// long-running operation should document the metadata type, if any.
+    #[prost(message, optional, tag = "2")]
+    pub metadata: ::core::option::Option<::prost_types::Any>,
+    /// If the value is `false`, it means the operation is still in progress.
+    /// If `true`, the operation is completed, and either `error` or `response` is
+    /// available.
+    #[prost(bool, tag = "3")]
+    pub done: bool,
+    /// The operation result, which can be either an `error` or a valid `response`.
+    /// If `done` == `false`, neither `error` nor `response` is set.
+    /// If `done` == `true`, exactly one of `error` or `response` is set.
+    #[prost(oneof = "operation::Result", tags = "4, 5")]
+    pub result: ::core::option::Option<operation::Result>,
+}
+/// Nested message and enum types in `Operation`.
+pub mod operation {
+    /// The operation result, which can be either an `error` or a valid `response`.
+    /// If `done` == `false`, neither `error` nor `response` is set.
+    /// If `done` == `true`, exactly one of `error` or `response` is set.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Result {
+        /// The error result of the operation in case of failure or cancellation.
+        #[prost(message, tag = "4")]
+        Error(super::super::rpc::Status),
+        /// The normal response of the operation in case of success.  If the original
+        /// method returns no data on success, such as `Delete`, the response is
+        /// `google.protobuf.Empty`.  If the original method is standard
+        /// `Get`/`Create`/`Update`, the response should be the resource.  For other
+        /// methods, the response should have the type `XxxResponse`, where `Xxx`
+        /// is the original method name.  For example, if the original method name
+        /// is `TakeSnapshot()`, the inferred response type is
+        /// `TakeSnapshotResponse`.
+        #[prost(message, tag = "5")]
+        Response(::prost_types::Any),
+    }
+}
+/// The request message for \[Operations.GetOperation][google.longrunning.Operations.GetOperation\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetOperationRequest {
+    /// The name of the operation resource.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// The request message for \[Operations.ListOperations][google.longrunning.Operations.ListOperations\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListOperationsRequest {
+    /// The name of the operation's parent resource.
+    #[prost(string, tag = "4")]
+    pub name: ::prost::alloc::string::String,
+    /// The standard list filter.
+    #[prost(string, tag = "1")]
+    pub filter: ::prost::alloc::string::String,
+    /// The standard list page size.
+    #[prost(int32, tag = "2")]
+    pub page_size: i32,
+    /// The standard list page token.
+    #[prost(string, tag = "3")]
+    pub page_token: ::prost::alloc::string::String,
+}
+/// The response message for \[Operations.ListOperations][google.longrunning.Operations.ListOperations\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListOperationsResponse {
+    /// A list of operations that matches the specified filter in the request.
+    #[prost(message, repeated, tag = "1")]
+    pub operations: ::prost::alloc::vec::Vec<Operation>,
+    /// The standard List next-page token.
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+}
+/// The request message for \[Operations.CancelOperation][google.longrunning.Operations.CancelOperation\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CancelOperationRequest {
+    /// The name of the operation resource to be cancelled.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// The request message for \[Operations.DeleteOperation][google.longrunning.Operations.DeleteOperation\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteOperationRequest {
+    /// The name of the operation resource to be deleted.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// The request message for \[Operations.WaitOperation][google.longrunning.Operations.WaitOperation\].
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WaitOperationRequest {
+    /// The name of the operation resource to wait on.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// The maximum duration to wait before timing out. If left blank, the wait
+    /// will be at most the time permitted by the underlying HTTP/RPC protocol.
+    /// If RPC context deadline is also specified, the shorter one will be used.
+    #[prost(message, optional, tag = "2")]
+    pub timeout: ::core::option::Option<::prost_types::Duration>,
+}
+/// A message representing the message types used by a long-running operation.
+///
+/// Example:
+///
+///   rpc LongRunningRecognize(LongRunningRecognizeRequest)
+///       returns (google.longrunning.Operation) {
+///     option (google.longrunning.operation_info) = {
+///       response_type: "LongRunningRecognizeResponse"
+///       metadata_type: "LongRunningRecognizeMetadata"
+///     };
+///   }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OperationInfo {
+    /// Required. The message name of the primary return type for this
+    /// long-running operation.
+    /// This type will be used to deserialize the LRO's response.
+    ///
+    /// If the response is in a different package from the rpc, a fully-qualified
+    /// message name must be used (e.g. `google.protobuf.Struct`).
+    ///
+    /// Note: Altering this value constitutes a breaking change.
+    #[prost(string, tag = "1")]
+    pub response_type: ::prost::alloc::string::String,
+    /// Required. The message name of the metadata type for this long-running
+    /// operation.
+    ///
+    /// If the response is in a different package from the rpc, a fully-qualified
+    /// message name must be used (e.g. `google.protobuf.Struct`).
+    ///
+    /// Note: Altering this value constitutes a breaking change.
+    #[prost(string, tag = "2")]
+    pub metadata_type: ::prost::alloc::string::String,
+}
+#[doc = r" Generated client implementations."]
+pub mod operations_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[doc = " Manages long-running operations with an API service."]
+    #[doc = ""]
+    #[doc = " When an API method normally takes long time to complete, it can be designed"]
+    #[doc = " to return [Operation][google.longrunning.Operation] to the client, and the client can use this"]
+    #[doc = " interface to receive the real response asynchronously by polling the"]
+    #[doc = " operation resource, or pass the operation resource to another API (such as"]
+    #[doc = " Google Cloud Pub/Sub API) to receive the response.  Any API service that"]
+    #[doc = " returns long-running operations should implement the `Operations` interface"]
+    #[doc = " so developers can have a consistent client experience."]
+    #[derive(Debug, Clone)]
+    pub struct OperationsClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl OperationsClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> OperationsClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> OperationsClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            OperationsClient::new(InterceptedService::new(inner, interceptor))
+        }
+        #[doc = r" Compress requests with `gzip`."]
+        #[doc = r""]
+        #[doc = r" This requires the server to support it otherwise it might respond with an"]
+        #[doc = r" error."]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        #[doc = r" Enable decompressing responses with `gzip`."]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        #[doc = " Lists operations that match the specified filter in the request. If the"]
+        #[doc = " server doesn't support this method, it returns `UNIMPLEMENTED`."]
+        #[doc = ""]
+        #[doc = " NOTE: the `name` binding allows API services to override the binding"]
+        #[doc = " to use different resource name schemes, such as `users/*/operations`. To"]
+        #[doc = " override the binding, API services can add a binding such as"]
+        #[doc = " `\"/v1/{name=users/*}/operations\"` to their service configuration."]
+        #[doc = " For backwards compatibility, the default name includes the operations"]
+        #[doc = " collection id, however overriding users must ensure the name binding"]
+        #[doc = " is the parent resource, without the operations collection id."]
+        pub async fn list_operations(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListOperationsRequest>,
+        ) -> Result<tonic::Response<super::ListOperationsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.longrunning.Operations/ListOperations",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Gets the latest state of a long-running operation.  Clients can use this"]
+        #[doc = " method to poll the operation result at intervals as recommended by the API"]
+        #[doc = " service."]
+        pub async fn get_operation(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetOperationRequest>,
+        ) -> Result<tonic::Response<super::Operation>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/google.longrunning.Operations/GetOperation");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Deletes a long-running operation. This method indicates that the client is"]
+        #[doc = " no longer interested in the operation result. It does not cancel the"]
+        #[doc = " operation. If the server doesn't support this method, it returns"]
+        #[doc = " `google.rpc.Code.UNIMPLEMENTED`."]
+        pub async fn delete_operation(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteOperationRequest>,
+        ) -> Result<tonic::Response<()>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.longrunning.Operations/DeleteOperation",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Starts asynchronous cancellation on a long-running operation.  The server"]
+        #[doc = " makes a best effort to cancel the operation, but success is not"]
+        #[doc = " guaranteed.  If the server doesn't support this method, it returns"]
+        #[doc = " `google.rpc.Code.UNIMPLEMENTED`.  Clients can use"]
+        #[doc = " [Operations.GetOperation][google.longrunning.Operations.GetOperation] or"]
+        #[doc = " other methods to check whether the cancellation succeeded or whether the"]
+        #[doc = " operation completed despite cancellation. On successful cancellation,"]
+        #[doc = " the operation is not deleted; instead, it becomes an operation with"]
+        #[doc = " an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,"]
+        #[doc = " corresponding to `Code.CANCELLED`."]
+        pub async fn cancel_operation(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CancelOperationRequest>,
+        ) -> Result<tonic::Response<()>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.longrunning.Operations/CancelOperation",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Waits until the specified long-running operation is done or reaches at most"]
+        #[doc = " a specified timeout, returning the latest state.  If the operation is"]
+        #[doc = " already done, the latest state is immediately returned.  If the timeout"]
+        #[doc = " specified is greater than the default HTTP/RPC timeout, the HTTP/RPC"]
+        #[doc = " timeout is used.  If the server does not support this method, it returns"]
+        #[doc = " `google.rpc.Code.UNIMPLEMENTED`."]
+        #[doc = " Note that this method is on a best-effort basis.  It may return the latest"]
+        #[doc = " state before the specified timeout (including immediately), meaning even an"]
+        #[doc = " immediate response is no guarantee that the operation is done."]
+        pub async fn wait_operation(
+            &mut self,
+            request: impl tonic::IntoRequest<super::WaitOperationRequest>,
+        ) -> Result<tonic::Response<super::Operation>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.longrunning.Operations/WaitOperation",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}

--- a/src/generated/google.pubsub.v1.rs
+++ b/src/generated/google.pubsub.v1.rs
@@ -612,10 +612,17 @@ pub struct Subscription {
     #[prost(string, tag = "2")]
     pub topic: ::prost::alloc::string::String,
     /// If push delivery is used with this subscription, this field is
-    /// used to configure it. An empty `pushConfig` signifies that the subscriber
-    /// will pull and ack messages using API methods.
+    /// used to configure it. Either `pushConfig` or `bigQueryConfig` can be set,
+    /// but not both. If both are empty, then the subscriber will pull and ack
+    /// messages using API methods.
     #[prost(message, optional, tag = "4")]
     pub push_config: ::core::option::Option<PushConfig>,
+    /// If delivery to BigQuery is used with this subscription, this field is
+    /// used to configure it. Either `pushConfig` or `bigQueryConfig` can be set,
+    /// but not both. If both are empty, then the subscriber will pull and ack
+    /// messages using API methods.
+    #[prost(message, optional, tag = "18")]
+    pub bigquery_config: ::core::option::Option<BigQueryConfig>,
     /// The approximate amount of time (on a best-effort basis) Pub/Sub waits for
     /// the subscriber to acknowledge receipt before resending the message. In the
     /// interval after the message is delivered and before it is acknowledged, it
@@ -706,6 +713,19 @@ pub struct Subscription {
     /// the endpoint will not be made.
     #[prost(bool, tag = "15")]
     pub detached: bool,
+    /// If true, Pub/Sub provides the following guarantees for the delivery of
+    /// a message with a given value of `message_id` on this subscription:
+    ///
+    /// * The message sent to a subscriber is guaranteed not to be resent
+    /// before the message's acknowledgement deadline expires.
+    /// * An acknowledged message will not be resent to a subscriber.
+    ///
+    /// Note that subscribers may still receive multiple copies of a message
+    /// when `enable_exactly_once_delivery` is true if the message was published
+    /// multiple times by a publisher client. These copies are  considered distinct
+    /// by Pub/Sub and have distinct `message_id` values.
+    #[prost(bool, tag = "16")]
+    pub enable_exactly_once_delivery: bool,
     /// Output only. Indicates the minimum duration for which a message is retained
     /// after it is published to the subscription's topic. If this field is set,
     /// messages published to the subscription's topic in the last
@@ -714,6 +734,26 @@ pub struct Subscription {
     /// in responses from the server; it is ignored if it is set in any requests.
     #[prost(message, optional, tag = "17")]
     pub topic_message_retention_duration: ::core::option::Option<::prost_types::Duration>,
+    /// Output only. An output-only field indicating whether or not the subscription can receive
+    /// messages.
+    #[prost(enumeration = "subscription::State", tag = "19")]
+    pub state: i32,
+}
+/// Nested message and enum types in `Subscription`.
+pub mod subscription {
+    /// Possible states for a subscription.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum State {
+        /// Default value. This value is unused.
+        Unspecified = 0,
+        /// The subscription can actively receive messages
+        Active = 1,
+        /// The subscription cannot receive messages because of an error with the
+        /// resource to which it pushes messages. See the more detailed error state
+        /// in the corresponding configuration.
+        ResourceError = 2,
+    }
 }
 /// A policy that specifies how Cloud Pub/Sub retries message delivery.
 ///
@@ -857,6 +897,54 @@ pub mod push_config {
         /// `Authorization` header in the HTTP request for every pushed message.
         #[prost(message, tag = "3")]
         OidcToken(OidcToken),
+    }
+}
+/// Configuration for a BigQuery subscription.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BigQueryConfig {
+    /// The name of the table to which to write data, of the form
+    /// {projectId}:{datasetId}.{tableId}
+    #[prost(string, tag = "1")]
+    pub table: ::prost::alloc::string::String,
+    /// When true, use the topic's schema as the columns to write to in BigQuery,
+    /// if it exists.
+    #[prost(bool, tag = "2")]
+    pub use_topic_schema: bool,
+    /// When true, write the subscription name, message_id, publish_time,
+    /// attributes, and ordering_key to additional columns in the table. The
+    /// subscription name, message_id, and publish_time fields are put in their own
+    /// columns while all other message properties (other than data) are written to
+    /// a JSON object in the attributes column.
+    #[prost(bool, tag = "3")]
+    pub write_metadata: bool,
+    /// When true and use_topic_schema is true, any fields that are a part of the
+    /// topic schema that are not part of the BigQuery table schema are dropped
+    /// when writing to BigQuery. Otherwise, the schemas must be kept in sync and
+    /// any messages with extra fields are not written and remain in the
+    /// subscription's backlog.
+    #[prost(bool, tag = "4")]
+    pub drop_unknown_fields: bool,
+    /// Output only. An output-only field that indicates whether or not the subscription can
+    /// receive messages.
+    #[prost(enumeration = "big_query_config::State", tag = "5")]
+    pub state: i32,
+}
+/// Nested message and enum types in `BigQueryConfig`.
+pub mod big_query_config {
+    /// Possible states for a BigQuery subscription.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum State {
+        /// Default value. This value is unused.
+        Unspecified = 0,
+        /// The subscription can actively send messages to BigQuery
+        Active = 1,
+        /// Cannot write to the BigQuery table because of permission denied errors.
+        PermissionDenied = 2,
+        /// Cannot write to the BigQuery table because it does not exist.
+        NotFound = 3,
+        /// Cannot write to the BigQuery table due to a schema mismatch.
+        SchemaMismatch = 4,
     }
 }
 /// A message and its corresponding acknowledgment ID.
@@ -1107,6 +1195,16 @@ pub struct StreamingPullResponse {
     /// Received Pub/Sub messages. This will not be empty.
     #[prost(message, repeated, tag = "1")]
     pub received_messages: ::prost::alloc::vec::Vec<ReceivedMessage>,
+    /// This field will only be set if `enable_exactly_once_delivery` is set to
+    /// `true`.
+    #[prost(message, optional, tag = "5")]
+    pub acknowledge_confirmation:
+        ::core::option::Option<streaming_pull_response::AcknowledgeConfirmation>,
+    /// This field will only be set if `enable_exactly_once_delivery` is set to
+    /// `true`.
+    #[prost(message, optional, tag = "3")]
+    pub modify_ack_deadline_confirmation:
+        ::core::option::Option<streaming_pull_response::ModifyAckDeadlineConfirmation>,
     /// Properties associated with this subscription.
     #[prost(message, optional, tag = "4")]
     pub subscription_properties:
@@ -1114,9 +1212,39 @@ pub struct StreamingPullResponse {
 }
 /// Nested message and enum types in `StreamingPullResponse`.
 pub mod streaming_pull_response {
+    /// Acknowledgement IDs sent in one or more previous requests to acknowledge a
+    /// previously received message.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct AcknowledgeConfirmation {
+        /// Successfully processed acknowledgement IDs.
+        #[prost(string, repeated, tag = "1")]
+        pub ack_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+        /// List of acknowledgement IDs that were malformed or whose acknowledgement
+        /// deadline has expired.
+        #[prost(string, repeated, tag = "2")]
+        pub invalid_ack_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+        /// List of acknowledgement IDs that were out of order.
+        #[prost(string, repeated, tag = "3")]
+        pub unordered_ack_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    }
+    /// Acknowledgement IDs sent in one or more previous requests to modify the
+    /// deadline for a specific message.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ModifyAckDeadlineConfirmation {
+        /// Successfully processed acknowledgement IDs.
+        #[prost(string, repeated, tag = "1")]
+        pub ack_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+        /// List of acknowledgement IDs that were malformed or whose acknowledgement
+        /// deadline has expired.
+        #[prost(string, repeated, tag = "2")]
+        pub invalid_ack_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    }
     /// Subscription properties sent as part of the response.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct SubscriptionProperties {
+        /// True iff exactly once delivery is enabled for this subscription.
+        #[prost(bool, tag = "1")]
+        pub exactly_once_delivery_enabled: bool,
         /// True iff message ordering is enabled for this subscription.
         #[prost(bool, tag = "2")]
         pub message_ordering_enabled: bool,

--- a/src/generated/google.rpc.rs
+++ b/src/generated/google.rpc.rs
@@ -1,0 +1,22 @@
+/// The `Status` type defines a logical error model that is suitable for
+/// different programming environments, including REST APIs and RPC APIs. It is
+/// used by \[gRPC\](<https://github.com/grpc>). Each `Status` message contains
+/// three pieces of data: error code, error message, and error details.
+///
+/// You can find out more about this error model and how to work with it in the
+/// [API Design Guide](<https://cloud.google.com/apis/design/errors>).
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Status {
+    /// The status code, which should be an enum value of \[google.rpc.Code][google.rpc.Code\].
+    #[prost(int32, tag = "1")]
+    pub code: i32,
+    /// A developer-facing error message, which should be in English. Any
+    /// user-facing error message should be localized and sent in the
+    /// \[google.rpc.Status.details][google.rpc.Status.details\] field, or localized by the client.
+    #[prost(string, tag = "2")]
+    pub message: ::prost::alloc::string::String,
+    /// A list of messages that carry the error details.  There is a common set of
+    /// message types for APIs to use.
+    #[prost(message, repeated, tag = "3")]
+    pub details: ::prost::alloc::vec::Vec<::prost_types::Any>,
+}

--- a/src/generated/google.type.rs
+++ b/src/generated/google.type.rs
@@ -1,0 +1,20 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Expr {
+    /// Textual representation of an expression in Common Expression Language
+    /// syntax.
+    #[prost(string, tag = "1")]
+    pub expression: ::prost::alloc::string::String,
+    /// Optional. Title for the expression, i.e. a short string describing
+    /// its purpose. This can be used e.g. in UIs which allow to enter the
+    /// expression.
+    #[prost(string, tag = "2")]
+    pub title: ::prost::alloc::string::String,
+    /// Optional. Description of the expression. This is a longer text which
+    /// describes the expression, e.g. when hovered over it in a UI.
+    #[prost(string, tag = "3")]
+    pub description: ::prost::alloc::string::String,
+    /// Optional. String indicating the location of the expression for error
+    /// reporting, e.g. a file name and a position in the file.
+    #[prost(string, tag = "4")]
+    pub location: ::prost::alloc::string::String,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,10 @@ macro_rules! config_default {
 
 pub mod auth;
 
+#[cfg(feature = "bigtable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bigtable")))]
+pub mod bigtable;
+
 #[cfg(feature = "grpc")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "pubsub", feature = "grpc"))))]
 pub mod grpc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,10 @@ pub mod auth;
 #[cfg_attr(docsrs, doc(cfg(feature = "bigtable")))]
 pub mod bigtable;
 
+#[cfg(feature = "emulators")]
+#[cfg_attr(docsrs, doc(cfg(feature = "emulators")))]
+pub(crate) mod emulator;
+
 #[cfg(feature = "grpc")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "pubsub", feature = "grpc"))))]
 pub mod grpc;

--- a/src/pubsub/emulator.rs
+++ b/src/pubsub/emulator.rs
@@ -14,49 +14,44 @@
 //! `ps aux | grep pubsub`. If there are open pubsub servers, run `pkill -f pubsub` to remove them
 //! all.
 
-use std::ops::Range;
+use futures::{future::BoxFuture, FutureExt};
 
 use crate::{
-    builder::{AuthFlow, ClientBuilder, ClientBuilderConfig},
+    builder::ClientBuilder,
+    emulator::{self, EmulatorData},
     pubsub,
 };
-use rand::{self, Rng};
-use std::path::Path;
 use tracing::debug;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-const PUBSUB_PROJECT_ID: &str = "test-project";
-const PORT_RANGE: Range<usize> = 8000..12000;
-const HOST: &str = "localhost";
-const PUBSUB_CLI_RETRY: usize = 100;
-const CLIENT_CONNECT_RETRY: usize = 50;
-
 /// Struct to hold a started PubSub emulator process. Process is closed when struct is dropped.
 pub struct EmulatorClient {
-    // Child process running the pubsub emulator. Killed on drop, `wait`ed by tokio in the
-    // background afterward.
-    _child: tokio::process::Child,
-
-    // The port where the emulator is running. e.g. 8050
-    port: String,
-
+    inner: crate::emulator::EmulatorClient,
     _temp: tempdir::TempDir,
+}
 
-    builder: ClientBuilder,
-
-    project_name: String,
+fn data(tmp_dir: &tempdir::TempDir) -> EmulatorData {
+    EmulatorData {
+        gcloud_param: "pubsub",
+        kill_pattern: "pubsub",
+        availability_check: create_schema_client,
+        extra_args: vec!["--data-dir".into(), tmp_dir.path().into()],
+    }
 }
 
 impl EmulatorClient {
     /// Create a new emulator instance with a default project name
     pub async fn new() -> Result<Self, BoxError> {
-        Self::with_project(PUBSUB_PROJECT_ID).await
+        let temp = tempdir::TempDir::new("pubsub_emulator")?;
+        Ok(EmulatorClient {
+            inner: emulator::EmulatorClient::new(data(&temp)).await?,
+            _temp: temp,
+        })
     }
 
     /// Create a new emulator instance with the given project name
     pub async fn with_project(project_name: impl Into<String>) -> Result<Self, BoxError> {
-        // Create a tmp dir where pubsub can store its data. Removed when EmulatorClient drops
         let temp = tempdir::TempDir::new("pubsub_emulator")?;
         debug!(
             path = temp.as_ref().to_str(),
@@ -65,56 +60,25 @@ impl EmulatorClient {
 
         let project_name = project_name.into();
 
-        let (child, port) = start_emulator(temp.path(), &project_name).await?;
-        debug!("Started emulator");
-
-        // Give the server some time (5s) to come up.
-        let mut err: Option<tonic::transport::Error> = None;
-        for _ in 0..CLIENT_CONNECT_RETRY {
-            // If we are able to create a schema client, then the server is up.
-            match create_schema_client(&port).await {
-                Err(e) => {
-                    err = Some(e);
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                }
-                Ok(_) => {
-                    err = None;
-                    break;
-                }
-            }
-        }
-
-        if let Some(err) = err {
-            return Err(err.into());
-        }
-
-        let config = ClientBuilderConfig {
-            auth_flow: AuthFlow::NoAuth,
-        };
-        let builder = ClientBuilder::new(config).await?;
-
-        Ok(Self {
-            _child: child,
-            port,
-            builder,
+        Ok(EmulatorClient {
+            inner: emulator::EmulatorClient::with_project(data(&temp), project_name).await?,
             _temp: temp,
-            project_name,
         })
     }
 
     /// Get the endpoint at which the emulator is listening for requests
     pub fn endpoint(&self) -> String {
-        format!("http://{}:{}/v1", HOST, self.port)
+        self.inner.endpoint()
     }
 
     /// Get the project name with which the emulator was initialized
     pub fn project(&self) -> &str {
-        &self.project_name
+        self.inner.project()
     }
 
     /// Get a client builder which is pre-configured to work with this emulator instance
     pub fn builder(&self) -> &ClientBuilder {
-        &self.builder
+        self.inner.builder()
     }
 
     /// Create a new topic under this emualtor's given project name
@@ -137,82 +101,17 @@ impl EmulatorClient {
     }
 }
 
-/// Hacked callback to ensure the emulator process cleans up after itself.
-impl Drop for EmulatorClient {
-    fn drop(&mut self) {
-        // Search by name for other pubsub processes with --port=PORT in the cmd name and kill
-        // them. https://googlecloudplatform.uservoice.com/forums/302631-cloud-pub-sub/suggestions/42574147-java-process-spawned-when-pub-sub-emulator-runs-is
-        tokio::spawn(
-            tokio::process::Command::new("pkill")
-                .arg("-f")
-                .arg(format!(".*pubsub.*--port={}.*", self.port))
-                .output(),
-        );
-    }
-}
-
-/// Attempt to start the PubSub emulator. Sometimes theres a port collision and this might fail
-/// so attempt it multiple times.
-async fn start_emulator(
-    tmp_dir: &Path,
-    project_name: &str,
-) -> Result<(tokio::process::Child, String), std::io::Error> {
-    let mut err: Option<_> = None;
-    let mut rng = rand::thread_rng();
-
-    for _ in 0..PUBSUB_CLI_RETRY {
-        let port = format!("{}", rng.gen_range(PORT_RANGE));
-        match start_emulator_once(&port, tmp_dir, project_name) {
-            Ok(child) => return Ok((child, port)),
-            Err(e) => {
-                err = Some(e);
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            }
-        }
-    }
-    Err(err.unwrap())
-}
-
-/// Attempt to start the PubSub emulator. Sometimes theres a port collision and this might fail.
-fn start_emulator_once(
-    port: &str,
-    tmp_dir: &Path,
-    project_name: &str,
-) -> Result<tokio::process::Child, std::io::Error> {
-    tokio::process::Command::new("gcloud")
-        .arg("beta")
-        .arg("emulators")
-        .arg("pubsub")
-        .arg("start")
-        .arg("--project")
-        .arg(project_name)
-        .arg("--host-port")
-        .arg(format!("{}:{}", HOST, port))
-        .arg("--data-dir")
-        .arg(tmp_dir)
-        .arg("--verbosity")
-        .arg("debug")
-        .kill_on_drop(true)
-        .spawn()
-}
-
 /// Creates the client to interact with PubSub schema service. Not currently supported by
 /// emulator.
-async fn create_schema_client(
-    port: &str,
-) -> Result<
-    pubsub::api::schema_service_client::SchemaServiceClient<
-        impl tonic::client::GrpcService<
-            tonic::body::BoxBody,
-            Error = tonic::transport::Error,
-            ResponseBody = tonic::transport::Body,
-        >,
-    >,
-    tonic::transport::Error,
-> {
-    pubsub::api::schema_service_client::SchemaServiceClient::connect(format!(
-        "http://{}:{}",
-        HOST, port
-    ))
-    .await
+fn create_schema_client(port: &str) -> BoxFuture<Result<(), tonic::transport::Error>> {
+    async move {
+        pubsub::api::schema_service_client::SchemaServiceClient::connect(format!(
+            "http://{}:{}",
+            crate::emulator::HOST,
+            port
+        ))
+        .await?;
+        Ok(())
+    }
+    .boxed()
 }

--- a/tests/bigtable_client.rs
+++ b/tests/bigtable_client.rs
@@ -127,7 +127,7 @@ mod bigtable_client_tests {
         assert_eq!(1, row.families[0].columns[0].cells.len());
         assert_eq!("data2", row.families[0].columns[0].cells[0].value);
         assert_eq!(
-            vec!["data2"],
+            vec!["data2".as_bytes()],
             row.most_recent_cells().map(|c| c.value).collect::<Vec<_>>()
         );
 
@@ -146,7 +146,7 @@ mod bigtable_client_tests {
         dbg!(row);
         assert_eq!(2, row.families[0].columns[0].cells.len());
         assert_eq!(
-            vec!["data2"],
+            vec!["data2".as_bytes()],
             row.most_recent_cells().map(|c| c.value).collect::<Vec<_>>()
         );
     }

--- a/tests/bigtable_client.rs
+++ b/tests/bigtable_client.rs
@@ -1,0 +1,153 @@
+#[cfg(all(feature = "bigtable", feature = "emulators"))]
+mod bigtable_client_tests {
+    use futures::TryStreamExt;
+    use hyper::body::Bytes;
+    use ya_gcp::bigtable::{self, admin::Rule, api, emulator::EmulatorClient, ReadRowsRequest};
+
+    #[tokio::test]
+    async fn create_table() {
+        let table_name = "test-table";
+        let emulator = EmulatorClient::new().await.unwrap();
+        let config = bigtable::admin::BigtableTableAdminConfig::new().endpoint(emulator.endpoint());
+        let mut admin = emulator
+            .builder()
+            .build_bigtable_admin_client(config, emulator.project(), emulator.instance())
+            .await
+            .unwrap();
+
+        admin
+            .create_table(table_name, [("column".into(), Rule::MaxNumVersions(1))])
+            .await
+            .unwrap();
+
+        let tables: Vec<_> = admin
+            .list_tables()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        assert_eq!(tables.len(), 1);
+        assert_eq!(
+            tables[0].name,
+            "projects/test-project/instances/test-instance/tables/test-table"
+        );
+    }
+
+    async fn default_client(table_name: &str) -> (EmulatorClient, bigtable::BigtableClient) {
+        let emulator = EmulatorClient::new().await.unwrap();
+        emulator
+            .create_table(table_name, ["fam1", "fam2"])
+            .await
+            .unwrap();
+
+        let config = bigtable::BigtableConfig::new().endpoint(emulator.endpoint());
+        let client = emulator
+            .builder()
+            .build_bigtable_client(config, emulator.project(), emulator.instance())
+            .await
+            .unwrap();
+        (emulator, client)
+    }
+
+    #[tokio::test]
+    async fn set_and_read_row() {
+        let table_name = "test-table";
+        let (_emulator, mut client) = default_client(table_name).await;
+
+        client
+            .set_row_data(
+                table_name,
+                "fam1".into(),
+                "row1-key",
+                [("col1", "data1"), ("col2", "data2")],
+            )
+            .await
+            .unwrap();
+
+        let row = client
+            .read_one_row(table_name, "row1-key")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!("row1-key", row.key);
+        assert_eq!(1, row.families.len());
+        assert_eq!("fam1", row.families[0].name);
+        dbg!(&row.families);
+        assert_eq!(2, row.families[0].columns.len());
+        assert_eq!("col1", row.families[0].columns[0].qualifier);
+        assert_eq!("data1", row.families[0].columns[0].cells[0].value);
+        assert_eq!("col2", row.families[0].columns[1].qualifier);
+        assert_eq!("data2", row.families[0].columns[1].cells[0].value);
+
+        let row_range: Vec<_> = client
+            .read_row_range(
+                table_name,
+                Bytes::from("row1-key")..=Bytes::from("row1-key"),
+                None,
+            )
+            .try_collect()
+            .await
+            .unwrap();
+        assert_eq!(row_range, vec![row]);
+    }
+
+    #[tokio::test]
+    async fn cell_versions() {
+        let table_name = "test-table";
+        let (emulator, mut client) = default_client(table_name).await;
+        client
+            .set_row_data_with_timestamp(
+                table_name,
+                "fam1".into(),
+                // The bigtable emulator enforces millisecond granularity
+                6000,
+                "row1-key",
+                [("col1", "data1")],
+            )
+            .await
+            .unwrap();
+        client
+            .set_row_data_with_timestamp(
+                table_name,
+                "fam1".into(),
+                7000,
+                "row1-key",
+                [("col1", "data2")],
+            )
+            .await
+            .unwrap();
+        let row = client
+            .read_one_row(table_name, "row1-key")
+            .await
+            .unwrap()
+            .unwrap();
+        // read_one_row only returns the latest version
+        assert_eq!(1, row.families[0].columns[0].cells.len());
+        assert_eq!("data2", row.families[0].columns[0].cells[0].value);
+        assert_eq!(
+            vec!["data2"],
+            row.most_recent_cells().map(|c| c.value).collect::<Vec<_>>()
+        );
+
+        let req = ReadRowsRequest {
+            table_name: format!(
+                "projects/{}/instances/{}/tables/{table_name}",
+                emulator.project(),
+                emulator.instance()
+            ),
+            rows: Some(api::bigtable::v2::RowSet::default().with_key("row1-key")),
+            ..Default::default()
+        };
+        let rows: Vec<_> = client.read_rows(req).try_collect().await.unwrap();
+        assert_eq!(1, rows.len());
+        let row = &rows[0];
+        dbg!(row);
+        assert_eq!(2, row.families[0].columns[0].cells.len());
+        assert_eq!(
+            vec!["data2"],
+            row.most_recent_cells().map(|c| c.value).collect::<Vec<_>>()
+        );
+    }
+}


### PR DESCRIPTION
I've been poking at this for a while, and I think it's gotten to the point where it's worth asking whether I'm on the right track. Apart from wrapping the bigtable api, it does just enough of the bigtable table admin api to be able to run examples on the bigtable emulator.

The main missing things I know of are
-  [x] any testing whatsoever (including support for conveniently spinning up an emulator)
-  [x] retry handing for reading (but it's complicated enough that I think testing support is needed first)