### PR TITLE
Update yup-oauth and add support for service account impersonation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,18 +1234,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.1",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
-dependencies = [
- "base64",
 ]
 
 [[package]]
@@ -2213,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "yup-oauth2"
-version = "6.7.1"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22978c3967bbb8ba0c100106d83e652cf640b55d64b7e7d93d943fc0738d9453"
+checksum = "f8cb398cca4dedd0203666d7c3e7a089d14557be759efd57ab75f067949276e7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2228,11 +2219,12 @@ dependencies = [
  "log",
  "percent-encoding",
  "rustls 0.20.7",
- "rustls-pemfile 0.3.0",
+ "rustls-pemfile",
  "seahash",
  "serde",
  "serde_json",
  "time 0.3.15",
  "tokio",
+ "tower-service",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 tracing = "0.1"
-yup-oauth2 = "6.7"
+yup-oauth2 = "8.1"
 
 async-stream = { version = "0.3", optional = true }
 async-channel = { version = "1", optional = true }

--- a/src/bigtable/admin.rs
+++ b/src/bigtable/admin.rs
@@ -1,7 +1,7 @@
 //! An API for administering bigtable.
 
 use crate::{
-    auth::grpc::{self, AuthGrpcService, OAuthTokenSource},
+    auth::grpc::{self, AuthGrpcService},
     builder,
 };
 
@@ -31,7 +31,7 @@ config_default! {
 #[derive(Clone)]
 pub struct BigtableTableAdminClient<C = crate::DefaultConnector> {
     pub(crate) inner: admin::v2::bigtable_table_admin_client::BigtableTableAdminClient<
-        AuthGrpcService<tonic::transport::Channel, OAuthTokenSource<C>>,
+        AuthGrpcService<tonic::transport::Channel, C>,
     >,
     // A string of the form projects/{project}/instances/{instance}
     pub(crate) table_prefix: String,
@@ -159,7 +159,7 @@ where
         let table_prefix = format!("projects/{}/instances/{}", project, instance_name);
 
         let inner = admin::v2::bigtable_table_admin_client::BigtableTableAdminClient::new(
-            grpc::oauth_grpc(connection, self.auth.clone(), scopes),
+            grpc::AuthGrpcService::new(connection, self.auth.clone(), scopes),
         );
 
         Ok(BigtableTableAdminClient {

--- a/src/bigtable/client_builder.rs
+++ b/src/bigtable/client_builder.rs
@@ -49,9 +49,15 @@ use super::BigtableRetryCheck;
 
 impl<C> builder::ClientBuilder<C>
 where
-    C: MakeConnection<Uri> + crate::Connect + Clone + Send + Sync + 'static,
-    C::Connection: Unpin + Send + 'static,
-    C::Future: Send + 'static,
+    C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+    C::Response: hyper::client::connect::Connection
+        + tokio::io::AsyncRead
+        + tokio::io::AsyncWrite
+        + Send
+        + Unpin
+        + 'static,
+    C::Future: Send + Unpin + 'static,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     Box<dyn std::error::Error + Send + Sync + 'static>: From<C::Error>,
 {
     /// Create a client for connecting to bigtable

--- a/src/bigtable/client_builder.rs
+++ b/src/bigtable/client_builder.rs
@@ -69,11 +69,9 @@ where
             .await?;
         let table_prefix = format!("projects/{}/instances/{}/tables/", project, instance_name);
 
-        let inner = api::bigtable::v2::bigtable_client::BigtableClient::new(grpc::oauth_grpc(
-            connection,
-            self.auth.clone(),
-            scopes,
-        ));
+        let inner = api::bigtable::v2::bigtable_client::BigtableClient::new(
+            grpc::AuthGrpcService::new(connection, self.auth.clone(), scopes),
+        );
 
         Ok(BigtableClient {
             inner,

--- a/src/bigtable/mod.rs
+++ b/src/bigtable/mod.rs
@@ -8,7 +8,7 @@ use prost::bytes::BytesMut;
 use std::ops::{Bound, RangeBounds};
 
 use crate::{
-    auth::grpc::{AuthGrpcService, OAuthTokenSource},
+    auth::grpc::{AuthGrpcService},
     retry_policy::{ExponentialBackoff, RetryOperation, RetryPolicy, RetryPredicate},
 };
 
@@ -370,7 +370,7 @@ pub struct BigtableClient<
     Retry = ExponentialBackoff<BigtableRetryCheck>,
 > {
     inner: api::bigtable::v2::bigtable_client::BigtableClient<
-        AuthGrpcService<tonic::transport::Channel, OAuthTokenSource<C>>,
+        AuthGrpcService<tonic::transport::Channel, C>,
     >,
     retry: Retry,
     table_prefix: String,

--- a/src/bigtable/mod.rs
+++ b/src/bigtable/mod.rs
@@ -8,7 +8,7 @@ use prost::bytes::BytesMut;
 use std::ops::{Bound, RangeBounds};
 
 use crate::{
-    auth::grpc::{AuthGrpcService},
+    auth::grpc::AuthGrpcService,
     retry_policy::{ExponentialBackoff, RetryOperation, RetryPolicy, RetryPredicate},
 };
 
@@ -378,7 +378,15 @@ pub struct BigtableClient<
 
 impl<C, Retry> BigtableClient<C, Retry>
 where
-    C: crate::Connect + Clone + Send + Sync + 'static,
+    C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+    C::Response: hyper::client::connect::Connection
+        + tokio::io::AsyncRead
+        + tokio::io::AsyncWrite
+        + Send
+        + Unpin
+        + 'static,
+    C::Future: Send + Unpin + 'static,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     Retry: RetryPolicy<(), tonic::Status> + 'static,
     Retry::RetryOp: Send + 'static,
     <Retry::RetryOp as RetryOperation<(), tonic::Status>>::Sleep: Send + 'static,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -184,7 +184,7 @@ impl<C> ClientBuilder<C> {
         connector: C,
     ) -> Result<Self, CreateBuilderError>
     where
-        C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+        C: hyper::service::Service<http::Uri> + Clone + Send + Sync + 'static,
         C::Response: hyper::client::connect::Connection
             + tokio::io::AsyncRead
             + tokio::io::AsyncWrite
@@ -261,7 +261,7 @@ async fn create_service_auth<C>(
     client: Client<C>,
 ) -> Result<Auth<C>, CreateBuilderError>
 where
-    C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+    C: hyper::service::Service<http::Uri> + Clone + Send + Sync + 'static,
     C::Response: hyper::client::connect::Connection
         + tokio::io::AsyncRead
         + tokio::io::AsyncWrite
@@ -315,7 +315,7 @@ async fn create_user_auth<C>(
     client: Client<C>,
 ) -> Result<Auth<C>, CreateBuilderError>
 where
-    C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+    C: hyper::service::Service<http::Uri> + Clone + Send + Sync + 'static,
     C::Response: hyper::client::connect::Connection
         + tokio::io::AsyncRead
         + tokio::io::AsyncWrite
@@ -343,7 +343,7 @@ async fn create_service_impersonation_auth<C>(
     client: Client<C>,
 ) -> Result<Auth<C>, CreateBuilderError>
 where
-    C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+    C: hyper::service::Service<http::Uri> + Clone + Send + Sync + 'static,
     C::Response: hyper::client::connect::Connection
         + tokio::io::AsyncRead
         + tokio::io::AsyncWrite

--- a/src/pubsub/client_builder.rs
+++ b/src/pubsub/client_builder.rs
@@ -40,15 +40,12 @@ where
     async fn pubsub_authed_service(
         &self,
         config: PubSubConfig,
-    ) -> Result<
-        grpc::AuthGrpcService<tonic::transport::Channel, grpc::OAuthTokenSource<C>>,
-        BuildError,
-    > {
+    ) -> Result<grpc::AuthGrpcService<tonic::transport::Channel, C>, BuildError> {
         let connection = tonic::transport::Endpoint::new(config.endpoint)?
             .connect_with_connector(self.connector.clone())
             .await?;
 
-        Ok(grpc::oauth_grpc(
+        Ok(grpc::AuthGrpcService::new(
             connection,
             self.auth.clone(),
             config.auth_scopes,

--- a/src/pubsub/client_builder.rs
+++ b/src/pubsub/client_builder.rs
@@ -32,9 +32,15 @@ pub struct BuildError(#[from] tonic::transport::Error);
 
 impl<C> builder::ClientBuilder<C>
 where
-    C: MakeConnection<Uri> + crate::Connect + Clone + Send + Sync + 'static,
-    C::Connection: Unpin + Send + 'static,
-    C::Future: Send + 'static,
+    C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+    C::Response: hyper::client::connect::Connection
+        + tokio::io::AsyncRead
+        + tokio::io::AsyncWrite
+        + Send
+        + Unpin
+        + 'static,
+    C::Future: Send + Unpin + 'static,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     Box<dyn std::error::Error + Send + Sync + 'static>: From<C::Error>,
 {
     async fn pubsub_authed_service(

--- a/src/pubsub/mod.rs
+++ b/src/pubsub/mod.rs
@@ -47,7 +47,15 @@ pub struct PublisherClient<C = crate::DefaultConnector> {
 
 impl<C> PublisherClient<C>
 where
-    C: crate::Connect + Clone + Send + Sync + 'static,
+    C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+    C::Response: hyper::client::connect::Connection
+        + tokio::io::AsyncRead
+        + tokio::io::AsyncWrite
+        + Send
+        + Unpin
+        + 'static,
+    C::Future: Send + Unpin + 'static,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     /// Create a sink which will publish [messages](api::PubsubMessage) to the given topic.
     ///
@@ -95,7 +103,15 @@ pub struct SubscriberClient<C = crate::DefaultConnector> {
 
 impl<C> SubscriberClient<C>
 where
-    C: crate::Connect + Clone + Send + Sync + 'static,
+    C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+    C::Response: hyper::client::connect::Connection
+        + tokio::io::AsyncRead
+        + tokio::io::AsyncWrite
+        + Send
+        + Unpin
+        + 'static,
+    C::Future: Send + Unpin + 'static,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     /// Start a streaming subscription with the pubsub service.
     ///

--- a/src/pubsub/mod.rs
+++ b/src/pubsub/mod.rs
@@ -3,10 +3,7 @@
 //! Publishing and topic management is done through the [`PublisherClient`], while reading data and
 //! subscription management is done through the [`SubscriberClient`].
 
-use crate::{
-    auth::grpc::{AuthGrpcService, OAuthTokenSource},
-    retry_policy::RetryPredicate,
-};
+use crate::{auth::grpc::AuthGrpcService, retry_policy::RetryPredicate};
 use std::fmt::Display;
 use tracing::debug_span;
 
@@ -43,11 +40,9 @@ pub mod api {
 ///
 /// This builds on top of the raw [gRPC publisher API](api::publisher_client::PublisherClient)
 /// to provide more ergonomic functionality
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct PublisherClient<C = crate::DefaultConnector> {
-    inner: api::publisher_client::PublisherClient<
-        AuthGrpcService<tonic::transport::Channel, OAuthTokenSource<C>>,
-    >,
+    inner: api::publisher_client::PublisherClient<AuthGrpcService<tonic::transport::Channel, C>>,
 }
 
 impl<C> PublisherClient<C>
@@ -73,9 +68,8 @@ where
 }
 
 impl<C> std::ops::Deref for PublisherClient<C> {
-    type Target = api::publisher_client::PublisherClient<
-        AuthGrpcService<tonic::transport::Channel, OAuthTokenSource<C>>,
-    >;
+    type Target =
+        api::publisher_client::PublisherClient<AuthGrpcService<tonic::transport::Channel, C>>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
@@ -94,11 +88,9 @@ impl<C> std::ops::DerefMut for PublisherClient<C> {
 ///
 /// This is an interface built on top of the raw [gRPC subscriber
 /// API](api::subscriber_client::SubscriberClient) which provides more ergonomic functionality
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SubscriberClient<C = crate::DefaultConnector> {
-    inner: api::subscriber_client::SubscriberClient<
-        AuthGrpcService<tonic::transport::Channel, OAuthTokenSource<C>>,
-    >,
+    inner: api::subscriber_client::SubscriberClient<AuthGrpcService<tonic::transport::Channel, C>>,
 }
 
 impl<C> SubscriberClient<C>
@@ -122,9 +114,8 @@ where
 }
 
 impl<C> std::ops::Deref for SubscriberClient<C> {
-    type Target = api::subscriber_client::SubscriberClient<
-        AuthGrpcService<tonic::transport::Channel, OAuthTokenSource<C>>,
-    >;
+    type Target =
+        api::subscriber_client::SubscriberClient<AuthGrpcService<tonic::transport::Channel, C>>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/src/pubsub/publish_sink.rs
+++ b/src/pubsub/publish_sink.rs
@@ -268,7 +268,15 @@ impl<C, Retry, ResponseSink: Sink<api::PubsubMessage>> PublishTopicSink<C, Retry
 
 impl<C, Retry, ResponseSink> Sink<api::PubsubMessage> for PublishTopicSink<C, Retry, ResponseSink>
 where
-    C: crate::Connect + Clone + Send + Sync + 'static,
+    C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+    C::Response: hyper::client::connect::Connection
+        + tokio::io::AsyncRead
+        + tokio::io::AsyncWrite
+        + Send
+        + Unpin
+        + 'static,
+    C::Future: Send + Unpin + 'static,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     // TODO(type_alias_impl_trait) remove most of these 'static (and Send?) bounds
     Retry: RetryPolicy<api::PublishRequest, tonic::Status> + 'static,
     Retry::RetryOp: Send + 'static,
@@ -314,7 +322,15 @@ where
 // borrowing/pinning in callers easier
 impl<'pin, C, Retry, ResponseSink> PublishTopicSinkProjection<'pin, C, Retry, ResponseSink>
 where
-    C: crate::Connect + Clone + Send + Sync + 'static,
+    C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+    C::Response: hyper::client::connect::Connection
+        + tokio::io::AsyncRead
+        + tokio::io::AsyncWrite
+        + Send
+        + Unpin
+        + 'static,
+    C::Future: Send + Unpin + 'static,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     Retry: RetryPolicy<api::PublishRequest, tonic::Status> + 'static,
     Retry::RetryOp: Send + 'static,
     <Retry::RetryOp as RetryOperation<api::PublishRequest, tonic::Status>>::Sleep: Send + 'static,

--- a/src/pubsub/publish_sink.rs
+++ b/src/pubsub/publish_sink.rs
@@ -1,6 +1,6 @@
 use super::{api, ProjectTopicName, PubSubRetryCheck};
 use crate::{
-    auth::grpc::{AuthGrpcService, OAuthTokenSource},
+    auth::grpc::AuthGrpcService,
     retry_policy::{exponential_backoff, ExponentialBackoff, RetryOperation, RetryPolicy},
 };
 use futures::{future::BoxFuture, ready, stream, Sink, SinkExt, TryFutureExt};
@@ -29,9 +29,8 @@ const MAX_MESSAGES_PER_PUBLISH: usize = 1000;
 const MAX_DATA_FIELD_BYTES: usize = 10 * MB;
 const MAX_PUBLISH_REQUEST_BYTES: usize = 10 * MB;
 
-type ApiPublisherClient<C> = api::publisher_client::PublisherClient<
-    AuthGrpcService<tonic::transport::Channel, OAuthTokenSource<C>>,
->;
+type ApiPublisherClient<C> =
+    api::publisher_client::PublisherClient<AuthGrpcService<tonic::transport::Channel, C>>;
 type Drain = futures::sink::Drain<api::PubsubMessage>;
 type FlushOutput<Si, E> = (Si, Result<(), SinkError<E>>);
 
@@ -745,7 +744,7 @@ mod test {
         // by connecting to the endpoint lazily, this client will only work until the first request
         // is made (then it will error). That's good enough for testing certain functionality
         // that doesn't require the requests themselves, like validity checking
-        ApiPublisherClient::new(crate::auth::grpc::oauth_grpc(
+        ApiPublisherClient::new(crate::auth::grpc::AuthGrpcService::new(
             tonic::transport::channel::Endpoint::from_static("https://localhost").connect_lazy(),
             None,
             vec![],

--- a/src/pubsub/streaming_subscription.rs
+++ b/src/pubsub/streaming_subscription.rs
@@ -368,7 +368,15 @@ impl<C, OldR> StreamSubscription<C, OldR> {
 
 impl<C, R> Stream for StreamSubscription<C, R>
 where
-    C: crate::Connect + Clone + Send + Sync + 'static,
+    C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+    C::Response: hyper::client::connect::Connection
+        + tokio::io::AsyncRead
+        + tokio::io::AsyncWrite
+        + Send
+        + Unpin
+        + 'static,
+    C::Future: Send + Unpin + 'static,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     R: RetryPolicy<(), tonic::Status> + Send + 'static,
     R::RetryOp: Send + 'static,
     <R::RetryOp as RetryOperation<(), tonic::Status>>::Sleep: Send + 'static,
@@ -426,7 +434,15 @@ fn stream_from_client<C, R>(
     mut retry_policy: R,
 ) -> impl Stream<Item = Result<(AcknowledgeToken, api::PubsubMessage), tonic::Status>> + Send + 'static
 where
-    C: crate::Connect + Clone + Send + Sync + 'static,
+    C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+    C::Response: hyper::client::connect::Connection
+        + tokio::io::AsyncRead
+        + tokio::io::AsyncWrite
+        + Send
+        + Unpin
+        + 'static,
+    C::Future: Send + Unpin + 'static,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     R: RetryPolicy<(), tonic::Status> + Send + 'static,
     R::RetryOp: Send + 'static,
     <R::RetryOp as RetryOperation<(), tonic::Status>>::Sleep: Send + 'static,

--- a/src/pubsub/streaming_subscription.rs
+++ b/src/pubsub/streaming_subscription.rs
@@ -16,7 +16,7 @@ use tonic::metadata::MetadataValue;
 use tracing::{debug, debug_span};
 
 use crate::{
-    auth::grpc::{AuthGrpcService, OAuthTokenSource},
+    auth::grpc::AuthGrpcService,
     pubsub::{api, PubSubRetryCheck},
     retry_policy::{exponential_backoff, ExponentialBackoff, RetryOperation, RetryPolicy},
 };
@@ -281,9 +281,8 @@ pub struct StreamSubscription<C = crate::DefaultConnector, R = ExponentialBackof
 /// could be called after streaming
 enum StreamState<C, R> {
     Initialized {
-        client: api::subscriber_client::SubscriberClient<
-            AuthGrpcService<tonic::transport::Channel, OAuthTokenSource<C>>,
-        >,
+        client:
+            api::subscriber_client::SubscriberClient<AuthGrpcService<tonic::transport::Channel, C>>,
         subscription: String,
         config: StreamSubscriptionConfig,
         retry_policy: R,
@@ -298,7 +297,7 @@ enum StreamState<C, R> {
 impl<C> StreamSubscription<C> {
     pub(super) fn new(
         client: api::subscriber_client::SubscriberClient<
-            AuthGrpcService<tonic::transport::Channel, OAuthTokenSource<C>>,
+            AuthGrpcService<tonic::transport::Channel, C>,
         >,
         subscription: String,
         config: StreamSubscriptionConfig,
@@ -306,7 +305,7 @@ impl<C> StreamSubscription<C> {
         StreamSubscription {
             state: StreamState::Initialized {
                 client,
-                subscription: subscription,
+                subscription,
                 config,
                 retry_policy: ExponentialBackoff::new(
                     PubSubRetryCheck::default(),
@@ -420,7 +419,7 @@ where
 /// error is retriable
 fn stream_from_client<C, R>(
     mut client: api::subscriber_client::SubscriberClient<
-        AuthGrpcService<tonic::transport::Channel, OAuthTokenSource<C>>,
+        AuthGrpcService<tonic::transport::Channel, C>,
     >,
     subscription: String,
     config: StreamSubscriptionConfig,

--- a/tests/pubsub_client.rs
+++ b/tests/pubsub_client.rs
@@ -10,7 +10,7 @@ mod pubsub_client_tests {
     use ya_gcp::{
         pubsub::{
             self, api::PubsubMessage, emulator::EmulatorClient, ProjectSubscriptionName,
-            ProjectTopicName, PublishConfig, PublisherClient, SinkError, StreamSubscriptionConfig,
+            ProjectTopicName, PublisherClient, SinkError, StreamSubscriptionConfig,
         },
         Connect,
     };


### PR DESCRIPTION
This PR's aim was to add service account impersonation as an authentication method, but in order to do this I had to update the version of `yup-oauth` to 8.1, which required quite a lot of changes.

The main one is that I removed the concept of `TokenSource` from this repository, for two reasons:

- first, `yup-oauth` changed a bunch of things regarding how tokens work (a big one is that token generation can produce `None` now), making `TokenSource` difficult to adapt;
- and second, because `TokenSource` was a bit redundant with `yup-oauth`'s own concept of [authenticators](https://docs.rs/yup-oauth2/latest/yup_oauth2/authenticator/index.html).

Since version 6, the library has added many new authenticators, covering (I think) the use cases that `TokenSource` was covering.  Instead of a token source, `AuthGrpcService` now carries an authenticator and a list of scopes.

Updating `yup-oauth` also required replacing the `C: crate::Connect + Clone + Send + Sync + 'static` bounds with the following mouthful:

```
C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
C::Response: hyper::client::connect::Connection
    + tokio::io::AsyncRead
    + tokio::io::AsyncWrite
    + Send
    + Unpin
    + 'static,
C::Future: Send + Unpin + 'static,
C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
```

the reason being that `hyper::Connect` is actually a private trait that cannot be implemented, and so `yup-oauth` changed at some point to the bounds above, which are equivalent, albeit annoying.