### PR TITLE
Make bigtable `BuildError` public.

### DIFF
--- a/src/bigtable/client_builder.rs
+++ b/src/bigtable/client_builder.rs
@@ -39,12 +39,6 @@ impl BigtableConfig {
 #[error(transparent)]
 pub struct BuildError(#[from] tonic::transport::Error);
 
-// re-export traits and types necessary for the bounds on public functions
-#[allow(unreachable_pub)] // the reachability lint seems faulty with parent module re-exports
-pub use http::Uri;
-#[allow(unreachable_pub)]
-pub use tower::make::MakeConnection;
-
 use super::BigtableRetryCheck;
 
 impl<C> builder::ClientBuilder<C>

--- a/src/bigtable/mod.rs
+++ b/src/bigtable/mod.rs
@@ -1,6 +1,7 @@
-//! TODO(docs!)
-
-// Primitives for reading/writing Bigtable tables
+//! An API for interacting with Google's [Bigtable](https://cloud.google.com/bigtable) database.
+//!
+//! The [`BigtableClient`] allows reading and writing to tables, while the [`BigtableTableAdminClient`]
+//! allows for creating and listing tables.
 
 use futures::prelude::*;
 use hyper::body::Bytes;

--- a/src/bigtable/mod.rs
+++ b/src/bigtable/mod.rs
@@ -20,7 +20,7 @@ mod client_builder;
 pub mod filters;
 pub mod mutation;
 
-pub use client_builder::BigtableConfig;
+pub use client_builder::{BigtableConfig, BuildError};
 pub use mutation::{MutateRowRequest, MutateRowsError, MutateRowsRequest};
 
 #[cfg(feature = "emulators")]


### PR DESCRIPTION
It was hidden in a private module and we forgot to re-export it. This also adds some missing module-level docs.