### PR TITLE
Allow . in bucket names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ grpc = ["tonic", "prost", "prost-types", "tower", "derive_more"]
 
 bigtable = ["async-stream", "grpc", "prost", "tower"]
 pubsub = ["grpc", "uuid", "async-stream", "pin-project", "async-channel", "tokio/time"]
-storage = ["tame-gcs"]
+storage = ["tame-gcs", "tower"]
 
 # whether to include service emulator implementations. useful for testing
 emulators = ["tempdir", "tokio/process"]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -211,7 +211,7 @@ where
 
         let request = objects::Object::download(&oid, None).map_err(ObjectError::InvalidRequest)?;
 
-        let response = dbg!(self.send_request(empty_body(request)).await?);
+        let response = self.send_request(empty_body(request)).await?;
 
         Ok(objects::DownloadObjectResponse::try_from_parts(response)
             .map_err(ObjectError::Failure)?


### PR DESCRIPTION
Bucket names in GCS are allowed to contain '.' (under some conditions; see [here](https://cloud.google.com/storage/docs/domain-name-verification)), but `tame-gcs` fails validation for those names, as reported [here](https://github.com/EmbarkStudios/tame-gcs/issues/58).

This PR works around the issue by copying tame-gcs's bucket verification code, and modifying it to allow '.'. It's written with the assumption that tame-gcs will eventually fix the issue and so we can remove this code; if we intended to actually keep this around, it would probably make more sense to integrate `BucketNameError` into `InvalidNameError`.

Also, while testing this I noticed that build fails with `--features=storage`, because of a missing `tower` dependency.