### PR TITLE
Experiment with custom service for bigtable.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,6 +2175,7 @@ dependencies = [
  "derive_more",
  "futures",
  "http",
+ "http-body",
  "humantime-serde",
  "hyper",
  "hyper-openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ tempdir = { version = "0.3", optional = true }
 tonic = { version = "0.6.2", optional = true }
 tower = { version = "0.4", features = ["make"], optional = true }
 uuid = { version = "0.8.1", features = ["v4"], optional = true }
+http-body = "0.4.5"
 
 [dev-dependencies]
 approx = "0.5"


### PR DESCRIPTION
This is a little outline for what "BYO grpcservice" could look like, just for bigtable so far. I couldn't figure out how to rope `ClientBuilder` into this, because the whole point of `ClientBuilder` is to reuse some of the service-building configuration.

If this seems reasonable, I think we could even go further by removing the `C` parameter from `ClientBuilder` and just always use `DefaultConnector`, the idea being that `ClientBuilder` is the "easy" mode without customization and so if you want to customize the connector, just customize the whole service.