### PR TITLE
Make emulator connection retries configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_toolchain: [1.63.0, ""] # MSRV + ("" = rust-toolchain version)
+        rust_toolchain: [1.64.0, ""] # MSRV + ("" = rust-toolchain version)
         # some features like emulators and openssl won't work on windows/mac; those are tested in test-xplat
         os: [ubuntu-latest]
         test_flags: ["", "--no-default-features", "--all-features"]

--- a/src/bigtable/emulator.rs
+++ b/src/bigtable/emulator.rs
@@ -49,6 +49,24 @@ impl EmulatorClient {
         })
     }
 
+    /// Create a new emulator instance with the given project name, instance name,
+    /// which retries connection the specified number of times.
+    pub async fn with_project_instance_and_connect_retry_limit(
+        project_name: impl Into<String>,
+        instance_name: impl Into<String>,
+        connect_retry_limit: usize,
+    ) -> Result<Self, BoxError> {
+        Ok(EmulatorClient {
+            inner: emulator::EmulatorClient::with_project_and_connect_retry_limit(
+                DATA,
+                project_name,
+                connect_retry_limit,
+            )
+            .await?,
+            instance: instance_name.into(),
+        })
+    }
+
     /// Get the endpoint at which the emulator is listening for requests
     pub fn endpoint(&self) -> String {
         self.inner.endpoint()

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -24,7 +24,6 @@ use tracing::debug;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-pub(crate) const PROJECT_ID_DEFAULT: &str = "test-project";
 const PORT_RANGE: Range<usize> = 8000..12000;
 pub(crate) const HOST: &str = "localhost";
 const CLI_RETRY: usize = 100;

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -24,11 +24,11 @@ use tracing::debug;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-const PROJECT_ID: &str = "test-project";
+pub(crate) const PROJECT_ID_DEFAULT: &str = "test-project";
 const PORT_RANGE: Range<usize> = 8000..12000;
 pub(crate) const HOST: &str = "localhost";
 const CLI_RETRY: usize = 100;
-const CLIENT_CONNECT_RETRY_DEFAULT: usize = 50;
+pub(crate) const CLIENT_CONNECT_RETRY_DEFAULT: usize = 50;
 
 #[derive(Clone)]
 pub(crate) struct EmulatorData {
@@ -59,24 +59,12 @@ pub(crate) struct EmulatorClient {
 }
 
 impl EmulatorClient {
-    /// Create a new emulator instance with a default project name
-    pub(crate) async fn new(data: EmulatorData) -> Result<Self, BoxError> {
-        Self::with_project(data, PROJECT_ID).await
-    }
-
-    /// Create a new emulator instance with the given project name
-    pub(crate) async fn with_project(
+    /// Create a new emulator instance wiht the given `EmulatorData`, project name
+    /// and limit to the number of connection retries.
+    pub(crate) async fn new(
         data: EmulatorData,
         project_name: impl Into<String>,
-    ) -> Result<Self, BoxError> {
-        Self::with_project_and_connect_retry_limit(data, project_name, CLIENT_CONNECT_RETRY_DEFAULT)
-            .await
-    }
-
-    pub(crate) async fn with_project_and_connect_retry_limit(
-        data: EmulatorData,
-        project_name: impl Into<String>,
-        connect_retry_limit: usize,
+        connection_retry_limit: usize,
     ) -> Result<Self, BoxError> {
         let project_name = project_name.into();
 
@@ -87,7 +75,7 @@ impl EmulatorClient {
         // Give the server some time (5s) to come up.
         let mut err: Option<tonic::transport::Error> = None;
         let check = data.availability_check;
-        for _ in 0..connect_retry_limit {
+        for _ in 0..connection_retry_limit {
             // If we are able to create a schema client, then the server is up.
             match check(&port).await {
                 Err(e) => {
@@ -160,10 +148,9 @@ async fn start_emulator(
     extra_args: &[OsString],
 ) -> Result<(tokio::process::Child, String), std::io::Error> {
     let mut err: Option<_> = None;
-    let mut rng = rand::thread_rng();
 
     for _ in 0..CLI_RETRY {
-        let port = format!("{}", rng.gen_range(PORT_RANGE));
+        let port = format!("{}", rand::thread_rng().gen_range(PORT_RANGE));
         match start_emulator_once(emulator_name, &port, project_name, extra_args) {
             Ok(child) => return Ok((child, port)),
             Err(e) => {

--- a/src/pubsub/emulator.rs
+++ b/src/pubsub/emulator.rs
@@ -14,16 +14,57 @@
 //! `ps aux | grep pubsub`. If there are open pubsub servers, run `pkill -f pubsub` to remove them
 //! all.
 
+use std::future::IntoFuture;
+
 use futures::{future::BoxFuture, FutureExt};
 
 use crate::{
     builder::ClientBuilder,
-    emulator::{self, EmulatorData},
+    emulator::{self, EmulatorData, CLIENT_CONNECT_RETRY_DEFAULT, PROJECT_ID_DEFAULT},
     pubsub,
 };
 use tracing::debug;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// An async builder for constructing an emulator.
+pub struct Emulator {
+    project: String,
+    connection_retry_limit: usize,
+}
+
+impl Emulator {
+    /// Returns a new async builder for constructing an emulator.
+    pub fn new() -> Self {
+        Self {
+            project: PROJECT_ID_DEFAULT.to_owned(),
+            connection_retry_limit: CLIENT_CONNECT_RETRY_DEFAULT,
+        }
+    }
+
+    /// The GCP project name the emulator should use.
+    pub fn project(mut self, project: impl Into<String>) -> Self {
+        self.project = project.into();
+        self
+    }
+
+    /// How many times the emulator client should attempt to connect to the
+    /// emulator before giving up. Retries occur every 100ms so, e.g., a value
+    /// of `50` will result in a total retry time of 5s.
+    pub fn connection_retry_limit(mut self, connection_retry_limit: usize) -> Self {
+        self.connection_retry_limit = connection_retry_limit;
+        self
+    }
+}
+
+impl IntoFuture for Emulator {
+    type Output = Result<EmulatorClient, BoxError>;
+    type IntoFuture = BoxFuture<'static, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        async move { EmulatorClient::new(self.project, self.connection_retry_limit).await }.boxed()
+    }
+}
 
 /// Struct to hold a started PubSub emulator process. Process is closed when struct is dropped.
 pub struct EmulatorClient {
@@ -41,45 +82,16 @@ fn data(tmp_dir: &tempdir::TempDir) -> EmulatorData {
 }
 
 impl EmulatorClient {
-    /// Create a new emulator instance with a default project name
-    pub async fn new() -> Result<Self, BoxError> {
-        let temp = tempdir::TempDir::new("pubsub_emulator")?;
-        Ok(EmulatorClient {
-            inner: emulator::EmulatorClient::new(data(&temp)).await?,
-            _temp: temp,
-        })
-    }
-
-    /// Create a new emulator instance with the given project name
-    pub async fn with_project(project_name: impl Into<String>) -> Result<Self, BoxError> {
-        let temp = tempdir::TempDir::new("pubsub_emulator")?;
-        debug!(
-            path = temp.as_ref().to_str(),
-            "Created emulator data directory"
-        );
-
-        let project_name = project_name.into();
-
-        Ok(EmulatorClient {
-            inner: emulator::EmulatorClient::with_project(data(&temp), project_name).await?,
-            _temp: temp,
-        })
-    }
-
     /// Create a new emulator instance with the given project name, which retries
     /// connection the specified number of times.
-    pub async fn with_project_and_connect_retry_limit(
+    async fn new(
         project_name: impl Into<String>,
         connect_retry_limit: usize,
     ) -> Result<Self, BoxError> {
         let temp = tempdir::TempDir::new("pubsub_emulator")?;
         Ok(EmulatorClient {
-            inner: emulator::EmulatorClient::with_project_and_connect_retry_limit(
-                data(&temp),
-                project_name,
-                connect_retry_limit,
-            )
-            .await?,
+            inner: emulator::EmulatorClient::new(data(&temp), project_name, connect_retry_limit)
+                .await?,
             _temp: temp,
         })
     }

--- a/src/pubsub/emulator.rs
+++ b/src/pubsub/emulator.rs
@@ -66,6 +66,24 @@ impl EmulatorClient {
         })
     }
 
+    /// Create a new emulator instance with the given project name, which retries
+    /// connection the specified number of times.
+    pub async fn with_project_and_connect_retry_limit(
+        project_name: impl Into<String>,
+        connect_retry_limit: usize,
+    ) -> Result<Self, BoxError> {
+        let temp = tempdir::TempDir::new("pubsub_emulator")?;
+        Ok(EmulatorClient {
+            inner: emulator::EmulatorClient::with_project_and_connect_retry_limit(
+                data(&temp),
+                project_name,
+                connect_retry_limit,
+            )
+            .await?,
+            _temp: temp,
+        })
+    }
+
     /// Get the endpoint at which the emulator is listening for requests
     pub fn endpoint(&self) -> String {
         self.inner.endpoint()

--- a/src/pubsub/publish_sink.rs
+++ b/src/pubsub/publish_sink.rs
@@ -975,7 +975,9 @@ mod test {
     #[cfg(feature = "emulators")]
     #[tokio::test]
     async fn message_responses_in_order() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let emulator = pubsub::emulator::Emulator::new().await?;
+        let emulator = pubsub::emulator::Emulator::new()
+            .project("test-project")
+            .await?;
         let project_topic =
             ProjectTopicName::new(emulator.project(), "message_responses_in_order_test");
         let project_subscription = pubsub::ProjectSubscriptionName::new(
@@ -1082,7 +1084,9 @@ mod test {
     #[cfg(feature = "emulators")]
     #[tokio::test]
     async fn user_sink_closed_with_flush() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let emulator = pubsub::emulator::Emulator::new().await?;
+        let emulator = pubsub::emulator::Emulator::new()
+            .project("test-project")
+            .await?;
         let project_topic = ProjectTopicName::new(emulator.project(), "user_sink_test");
 
         let mut publisher = emulator

--- a/src/pubsub/publish_sink.rs
+++ b/src/pubsub/publish_sink.rs
@@ -975,7 +975,7 @@ mod test {
     #[cfg(feature = "emulators")]
     #[tokio::test]
     async fn message_responses_in_order() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let emulator = pubsub::emulator::EmulatorClient::new().await?;
+        let emulator = pubsub::emulator::Emulator::new().await?;
         let project_topic =
             ProjectTopicName::new(emulator.project(), "message_responses_in_order_test");
         let project_subscription = pubsub::ProjectSubscriptionName::new(
@@ -1082,7 +1082,7 @@ mod test {
     #[cfg(feature = "emulators")]
     #[tokio::test]
     async fn user_sink_closed_with_flush() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let emulator = pubsub::emulator::EmulatorClient::new().await?;
+        let emulator = pubsub::emulator::Emulator::new().await?;
         let project_topic = ProjectTopicName::new(emulator.project(), "user_sink_test");
 
         let mut publisher = emulator

--- a/tests/bigtable_client.rs
+++ b/tests/bigtable_client.rs
@@ -13,7 +13,11 @@ mod bigtable_client_tests {
     #[tokio::test]
     async fn create_table() {
         let table_name = "test-table";
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new()
+            .project("test-project")
+            .instance("test-instance")
+            .await
+            .unwrap();
         let config = bigtable::admin::BigtableTableAdminConfig::new().endpoint(emulator.endpoint());
         let mut admin = emulator
             .builder()
@@ -42,7 +46,11 @@ mod bigtable_client_tests {
     }
 
     async fn default_client(table_name: &str) -> (EmulatorClient, bigtable::BigtableClient) {
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new()
+            .project("test-project")
+            .instance("test-instance")
+            .await
+            .unwrap();
         emulator
             .create_table(table_name, ["fam1", "fam2"])
             .await

--- a/tests/bigtable_client.rs
+++ b/tests/bigtable_client.rs
@@ -2,12 +2,18 @@
 mod bigtable_client_tests {
     use futures::TryStreamExt;
     use hyper::body::Bytes;
-    use ya_gcp::bigtable::{self, admin::Rule, api, emulator::EmulatorClient, ReadRowsRequest};
+    use ya_gcp::bigtable::{
+        self,
+        admin::Rule,
+        api,
+        emulator::{Emulator, EmulatorClient},
+        ReadRowsRequest,
+    };
 
     #[tokio::test]
     async fn create_table() {
         let table_name = "test-table";
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = bigtable::admin::BigtableTableAdminConfig::new().endpoint(emulator.endpoint());
         let mut admin = emulator
             .builder()
@@ -36,7 +42,7 @@ mod bigtable_client_tests {
     }
 
     async fn default_client(table_name: &str) -> (EmulatorClient, bigtable::BigtableClient) {
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         emulator
             .create_table(table_name, ["fam1", "fam2"])
             .await

--- a/tests/pubsub_client.rs
+++ b/tests/pubsub_client.rs
@@ -8,8 +8,8 @@ mod pubsub_client_tests {
         time::Duration,
     };
     use ya_gcp::pubsub::{
-        self, api::PubsubMessage, emulator::EmulatorClient, ProjectSubscriptionName,
-        ProjectTopicName, PublisherClient, SinkError, StreamSubscriptionConfig,
+        self, api::PubsubMessage, emulator::Emulator, ProjectSubscriptionName, ProjectTopicName,
+        PublisherClient, SinkError, StreamSubscriptionConfig,
     };
 
     /// Helper to create a new topic request.
@@ -106,12 +106,12 @@ mod pubsub_client_tests {
 
     #[tokio::test]
     async fn build_emulator() {
-        EmulatorClient::new().await.unwrap();
+        Emulator::new().await.unwrap();
     }
 
     #[tokio::test]
     async fn build_publisher_client() {
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         emulator
             .builder()
@@ -122,7 +122,7 @@ mod pubsub_client_tests {
 
     #[tokio::test]
     async fn build_subscriber_client() {
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         emulator
             .builder()
@@ -134,7 +134,7 @@ mod pubsub_client_tests {
     #[tokio::test]
     async fn create_topic() {
         let topic_name = "test-topic";
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut client = emulator
             .builder()
@@ -157,7 +157,7 @@ mod pubsub_client_tests {
     #[tokio::test]
     async fn get_topic() {
         let topic_name = "test-topic";
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut client = emulator
             .builder()
@@ -186,7 +186,7 @@ mod pubsub_client_tests {
     // Publish a single list of messages.
     async fn publish() {
         let topic_name = "test-topic";
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
 
         let mut client = emulator
@@ -223,7 +223,7 @@ mod pubsub_client_tests {
     #[tokio::test]
     async fn list_topic_subscriptions() {
         let topic_name = "test-topic";
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut client = emulator
             .builder()
@@ -256,7 +256,7 @@ mod pubsub_client_tests {
     async fn create_subscription() {
         let topic_name = "test-topic";
         let subscription_name = "test-subscription";
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
 
         let mut client = emulator
@@ -294,7 +294,7 @@ mod pubsub_client_tests {
         let subscription_name = "test-subscription";
         let num_messages = 100;
 
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut publish_client = emulator
             .builder()
@@ -360,7 +360,7 @@ mod pubsub_client_tests {
     // for the stream.
     async fn create_subscription_stream_none_exists() {
         let subscription_name = "test-subscription";
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
 
         let mut client = emulator
@@ -391,7 +391,7 @@ mod pubsub_client_tests {
     async fn create_subscription_stream_empty() {
         let topic_name = "test-topic";
         let subscription_name = "test-subscription";
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut client = emulator
             .builder()
@@ -437,7 +437,7 @@ mod pubsub_client_tests {
     async fn create_subscription_stream_one() {
         let topic_name = "test-topic";
         let subscription_name = "test-subscription";
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut publish_client = emulator
             .builder()
@@ -507,7 +507,7 @@ mod pubsub_client_tests {
         let num_message_batches = 20;
         let total_messages = num_messages * num_message_batches;
 
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut publish_client = emulator
             .builder()
@@ -580,7 +580,7 @@ mod pubsub_client_tests {
         // lost. Since we ack these right away, we can't get them back.
         let total_messages = num_messages * (num_message_batches - 1);
 
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut publish_client = emulator
             .builder()
@@ -665,7 +665,7 @@ mod pubsub_client_tests {
         let batches = inner_step * outer_step;
         let total_messages = num_messages * batches;
 
-        let emulator = EmulatorClient::with_project(project_name).await.unwrap();
+        let emulator = Emulator::new().project(project_name).await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
 
         let mut publish_client = emulator
@@ -757,7 +757,7 @@ mod pubsub_client_tests {
         let topic_name = "test-topic";
         let subscription_name = "test-subscription";
 
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
 
         let mut publish_client = emulator
@@ -854,7 +854,7 @@ mod pubsub_client_tests {
         let topic_name = "test-topic";
         let subscription_name = "test-subscription";
 
-        let emulator = EmulatorClient::new().await.unwrap();
+        let emulator = Emulator::new().await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
 
         let mut publish_client = emulator
@@ -962,7 +962,7 @@ mod pubsub_client_tests {
             let topic_name = "test-topic";
             let subscription_name = "test-subscription";
 
-            let emulator = EmulatorClient::new().await.unwrap();
+            let emulator = Emulator::new().await.unwrap();
             let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
 
             let mut publish_client = emulator

--- a/tests/pubsub_client.rs
+++ b/tests/pubsub_client.rs
@@ -106,12 +106,12 @@ mod pubsub_client_tests {
 
     #[tokio::test]
     async fn build_emulator() {
-        Emulator::new().await.unwrap();
+        Emulator::new().project("test-project").await.unwrap();
     }
 
     #[tokio::test]
     async fn build_publisher_client() {
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         emulator
             .builder()
@@ -122,7 +122,7 @@ mod pubsub_client_tests {
 
     #[tokio::test]
     async fn build_subscriber_client() {
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         emulator
             .builder()
@@ -134,7 +134,7 @@ mod pubsub_client_tests {
     #[tokio::test]
     async fn create_topic() {
         let topic_name = "test-topic";
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut client = emulator
             .builder()
@@ -157,7 +157,7 @@ mod pubsub_client_tests {
     #[tokio::test]
     async fn get_topic() {
         let topic_name = "test-topic";
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut client = emulator
             .builder()
@@ -186,7 +186,7 @@ mod pubsub_client_tests {
     // Publish a single list of messages.
     async fn publish() {
         let topic_name = "test-topic";
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
 
         let mut client = emulator
@@ -223,7 +223,7 @@ mod pubsub_client_tests {
     #[tokio::test]
     async fn list_topic_subscriptions() {
         let topic_name = "test-topic";
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut client = emulator
             .builder()
@@ -256,7 +256,7 @@ mod pubsub_client_tests {
     async fn create_subscription() {
         let topic_name = "test-topic";
         let subscription_name = "test-subscription";
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
 
         let mut client = emulator
@@ -294,7 +294,7 @@ mod pubsub_client_tests {
         let subscription_name = "test-subscription";
         let num_messages = 100;
 
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut publish_client = emulator
             .builder()
@@ -360,7 +360,7 @@ mod pubsub_client_tests {
     // for the stream.
     async fn create_subscription_stream_none_exists() {
         let subscription_name = "test-subscription";
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
 
         let mut client = emulator
@@ -391,7 +391,7 @@ mod pubsub_client_tests {
     async fn create_subscription_stream_empty() {
         let topic_name = "test-topic";
         let subscription_name = "test-subscription";
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut client = emulator
             .builder()
@@ -437,7 +437,7 @@ mod pubsub_client_tests {
     async fn create_subscription_stream_one() {
         let topic_name = "test-topic";
         let subscription_name = "test-subscription";
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut publish_client = emulator
             .builder()
@@ -507,7 +507,7 @@ mod pubsub_client_tests {
         let num_message_batches = 20;
         let total_messages = num_messages * num_message_batches;
 
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut publish_client = emulator
             .builder()
@@ -580,7 +580,7 @@ mod pubsub_client_tests {
         // lost. Since we ack these right away, we can't get them back.
         let total_messages = num_messages * (num_message_batches - 1);
 
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
         let mut publish_client = emulator
             .builder()
@@ -757,7 +757,7 @@ mod pubsub_client_tests {
         let topic_name = "test-topic";
         let subscription_name = "test-subscription";
 
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
 
         let mut publish_client = emulator
@@ -854,7 +854,7 @@ mod pubsub_client_tests {
         let topic_name = "test-topic";
         let subscription_name = "test-subscription";
 
-        let emulator = Emulator::new().await.unwrap();
+        let emulator = Emulator::new().project("test-project").await.unwrap();
         let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
 
         let mut publish_client = emulator
@@ -962,7 +962,7 @@ mod pubsub_client_tests {
             let topic_name = "test-topic";
             let subscription_name = "test-subscription";
 
-            let emulator = Emulator::new().await.unwrap();
+            let emulator = Emulator::new().project("test-project").await.unwrap();
             let config = pubsub::PubSubConfig::new().endpoint(emulator.endpoint());
 
             let mut publish_client = emulator


### PR DESCRIPTION
We're seeing test flakiness when using the Bigtable and Pub/Sub emulators in CI. As far as we can tell this is caused by the connection timing out. I've tested this change in our CI (by bumping the timeout to 30 seconds) and it fixes the issue.

There are almost certainly better ways to pass this config in, so please feel free to suggest improvements.