### PR TITLE
Retry Ack/Nack/ModAck requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "ya-gcp"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "approx",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-gcp"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Renar Narubin <renar@standard.ai>"]
 edition = "2021"
 description = "APIs for using Google Cloud Platform services"


### PR DESCRIPTION
The changes in #37 did not attempt retries on the explicit ack requests. These appear to fail in practice periodically (~1hr), perhaps due to some connection resets from the server.

This change introduces retries to those requests