### PR TITLE
fix: Remove unnecessary `.into()`

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -93,7 +93,7 @@ fn bucket(name: &str) -> Result<BucketName, api::Error> {
         return Err(api::Error::InvalidSequence("google"));
     }
 
-    Ok(BucketName::non_validated(name.into()))
+    Ok(BucketName::non_validated(name))
 }
 
 fn names_to_object<'a>(


### PR DESCRIPTION
Remove unnecessary `.into()`

```sh
   Compiling ya-gcp v0.11.3
error[E0283]: type annotations needed
  --> /home/kamiyaa/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ya-gcp-0.11.3/src/storage.rs:96:8
   |
96 |     Ok(BucketName::non_validated(name.into()))
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ ----------- type must be known at this point
   |        |
   |        cannot infer type of the type parameter `S` declared on the associated function `non_validated`
   |
   = note: cannot satisfy `_: AsRef<str>`
note: required by a bound in `BucketName::<'a>::non_validated`
  --> /home/kamiyaa/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tame-gcs-0.10.0/src/types.rs:17:29
   |
17 |     pub fn non_validated<S: AsRef<str> + ?Sized>(name: &'a S) -> Self {
   |                             ^^^^^^^^^^ required by this bound in `BucketName::<'a>::non_validated`
help: consider specifying the generic argument
   |
96 |     Ok(BucketName::non_validated::<S>(name.into()))
   |                                 +++++
help: consider removing this method call, as the receiver has type `&str` and `&str: AsRef<str>` trivially holds
   |
96 -     Ok(BucketName::non_validated(name.into()))
96 +     Ok(BucketName::non_validated(name))
   |

error[E0283]: type annotations needed
  --> /home/kamiyaa/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ya-gcp-0.11.3/src/storage.rs:96:39
   |
96 |     Ok(BucketName::non_validated(name.into()))
   |                                       ^^^^
   |
   = note: multiple `impl`s satisfying `&_: From<&str>` found in the following crates: `core`, `zerovec`:
           - impl<'a> From<&'a str> for &'a zerovec::ule::unvalidated::UnvalidatedStr;
           - impl<T> From<T> for T;
   = note: required for `&str` to implement `Into<&_>`
help: try using a fully qualified path to specify the expected types
   |
96 |     Ok(BucketName::non_validated(<&str as Into<&S>>::into(name)))
   |                                  +++++++++++++++++++++++++    ~

For more information about this error, try `rustc --explain E0283`.
error: could not compile `ya-gcp` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```