### PR TITLE
Bump crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,7 +2140,7 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "ya-gcp"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "approx",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-gcp"
-version = "0.11.3"
+version = "0.12.0"
 authors = ["Renar Narubin <renar@standard.ai>"]
 edition = "2021"
 description = "APIs for using Google Cloud Platform services"


### PR DESCRIPTION
Bump crate version to publish changes from https://github.com/standard-ai/ya-gcp/pull/49.